### PR TITLE
[LITO-148] feat: chat-gpt 기능 구현

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    //chat gpt
+    implementation 'com.theokanning.openai-gpt3-java:service:0.14.0'
+
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'

--- a/api/src/docs/asciidoc/chat.adoc
+++ b/api/src/docs/asciidoc/chat.adoc
@@ -1,0 +1,19 @@
+= chat API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+== chat-gpt 질문하기
+
+=== 요청
+include::{snippets}/chat-controller-test/send_success/http-request.adoc[]
+include::{snippets}/chat-controller-test/send_success/request-headers.adoc[]
+include::{snippets}/chat-controller-test/send_success/request-fields.adoc[]
+
+=== 응답
+include::{snippets}/chat-controller-test/send_success/http-response.adoc[]
+include::{snippets}/chat-controller-test/send_success/response-fields.adoc[]
+

--- a/api/src/docs/asciidoc/index.adoc
+++ b/api/src/docs/asciidoc/index.adoc
@@ -21,4 +21,4 @@ include::overview.adoc[]
 * link:problem.html[Problem API, window=_blank]
 
 === Chat
-* link:chat.html
+* link:chat.html[Chat API, window=_blank]

--- a/api/src/docs/asciidoc/index.adoc
+++ b/api/src/docs/asciidoc/index.adoc
@@ -19,3 +19,6 @@ include::overview.adoc[]
 
 === Problem
 * link:problem.html[Problem API, window=_blank]
+
+=== Chat
+* link:chat.html

--- a/api/src/main/java/com/swm/lito/api/auth/adapter/in/web/AuthController.java
+++ b/api/src/main/java/com/swm/lito/api/auth/adapter/in/web/AuthController.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.auth.adapter.in.presentation;
+package com.swm.lito.api.auth.adapter.in.web;
 
 import com.swm.lito.api.auth.adapter.in.request.LoginRequest;
 import com.swm.lito.api.auth.adapter.in.response.LoginResponse;
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import static com.swm.lito.core.user.domain.enums.Provider.toEnum;
 
 @RestController
 @RequestMapping("/api/v1/auth")

--- a/api/src/main/java/com/swm/lito/api/chat/adapter/in/presentation/ChatController.java
+++ b/api/src/main/java/com/swm/lito/api/chat/adapter/in/presentation/ChatController.java
@@ -1,0 +1,23 @@
+package com.swm.lito.api.chat.adapter.in.presentation;
+
+import com.swm.lito.api.chat.adapter.in.request.ChatGPTCompletionRequest;
+import com.swm.lito.api.chat.adapter.in.response.ChatGPTCompletionResponse;
+import com.swm.lito.core.chat.application.port.in.ChatCommandUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chat-gpt")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatCommandUseCase chatCommandUseCase;
+
+    @PostMapping
+    public ChatGPTCompletionResponse send(@RequestBody ChatGPTCompletionRequest request){
+        return ChatGPTCompletionResponse.from(chatCommandUseCase.send(request.toRequestDto()));
+    }
+}

--- a/api/src/main/java/com/swm/lito/api/chat/adapter/in/presentation/ChatController.java
+++ b/api/src/main/java/com/swm/lito/api/chat/adapter/in/presentation/ChatController.java
@@ -3,11 +3,10 @@ package com.swm.lito.api.chat.adapter.in.presentation;
 import com.swm.lito.api.chat.adapter.in.request.ChatGPTCompletionRequest;
 import com.swm.lito.api.chat.adapter.in.response.ChatGPTCompletionResponse;
 import com.swm.lito.core.chat.application.port.in.ChatCommandUseCase;
+import com.swm.lito.core.common.security.AuthUser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/chat-gpt")
@@ -16,8 +15,10 @@ public class ChatController {
 
     private final ChatCommandUseCase chatCommandUseCase;
 
-    @PostMapping
-    public ChatGPTCompletionResponse send(@RequestBody ChatGPTCompletionRequest request){
-        return ChatGPTCompletionResponse.from(chatCommandUseCase.send(request.toRequestDto()));
+    @PostMapping("/{problemId}")
+    public ChatGPTCompletionResponse send(@AuthenticationPrincipal AuthUser authUser,
+                                          @PathVariable Long problemId,
+                                          @RequestBody ChatGPTCompletionRequest request){
+        return ChatGPTCompletionResponse.from(chatCommandUseCase.send(authUser, problemId, request.toRequestDto()));
     }
 }

--- a/api/src/main/java/com/swm/lito/api/chat/adapter/in/request/ChatGPTCompletionRequest.java
+++ b/api/src/main/java/com/swm/lito/api/chat/adapter/in/request/ChatGPTCompletionRequest.java
@@ -1,0 +1,35 @@
+package com.swm.lito.api.chat.adapter.in.request;
+
+import com.swm.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatGPTCompletionRequest {
+
+    private String model;
+
+    private String role;
+
+    private String message;
+
+    private Integer maxTokens;
+
+    public ChatGPTCompletionRequestDto toRequestDto(){
+        return ChatGPTCompletionRequestDto.builder()
+                .model(model)
+                .role(role)
+                .message(message)
+                .maxTokens(maxTokens)
+                .build();
+    }
+}

--- a/api/src/main/java/com/swm/lito/api/chat/adapter/in/request/ChatGPTCompletionRequest.java
+++ b/api/src/main/java/com/swm/lito/api/chat/adapter/in/request/ChatGPTCompletionRequest.java
@@ -16,20 +16,10 @@ import java.util.List;
 @Builder
 public class ChatGPTCompletionRequest {
 
-    private String model;
-
-    private String role;
-
     private String message;
 
-    private Integer maxTokens;
 
     public ChatGPTCompletionRequestDto toRequestDto(){
-        return ChatGPTCompletionRequestDto.builder()
-                .model(model)
-                .role(role)
-                .message(message)
-                .maxTokens(maxTokens)
-                .build();
+        return ChatGPTCompletionRequestDto.from(message);
     }
 }

--- a/api/src/main/java/com/swm/lito/api/chat/adapter/in/response/ChatGPTCompletionResponse.java
+++ b/api/src/main/java/com/swm/lito/api/chat/adapter/in/response/ChatGPTCompletionResponse.java
@@ -1,0 +1,94 @@
+package com.swm.lito.api.chat.adapter.in.response;
+
+import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatGPTCompletionResponse {
+
+    private String id;
+
+    private String object;
+
+    private Long created;
+
+    private String model;
+
+    private List<Message> messages;
+
+    private Usage usage;
+
+    public static ChatGPTCompletionResponse from(ChatGPTCompletionResponseDto responseDto){
+        return ChatGPTCompletionResponse.builder()
+                .id(responseDto.getId())
+                .object(responseDto.getObject())
+                .created(responseDto.getCreated())
+                .model(responseDto.getModel())
+                .messages(Message.from(responseDto.getMessages()))
+                .usage(Usage.from(responseDto.getUsage()))
+                .build();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Message {
+
+        private String role;
+
+        private String message;
+
+        public static Message from(ChatMessage chatMessage) {
+            return Message.builder()
+                    .message(chatMessage.getRole())
+                    .message(chatMessage.getContent())
+                    .build();
+        }
+
+        public static List<Message> from(List<ChatGPTCompletionResponseDto.Message> messages){
+            return messages.stream()
+                    .map(Message::from)
+                    .collect(Collectors.toList());
+        }
+
+        public static Message from(ChatGPTCompletionResponseDto.Message message){
+            return Message.builder()
+                    .role(message.getRole())
+                    .message(message.getMessage())
+                    .build();
+        }
+    }
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Usage {
+
+        private Long promptTokens;
+
+        private Long completionTokens;
+
+        private Long totalTokens;
+
+        public static Usage from(ChatGPTCompletionResponseDto.Usage usage){
+            return Usage.builder()
+                    .promptTokens(usage.getPromptTokens())
+                    .completionTokens(usage.getCompletionTokens())
+                    .totalTokens(usage.getTotalTokens())
+                    .build();
+        }
+    }
+}

--- a/api/src/main/java/com/swm/lito/api/chat/adapter/in/web/ChatController.java
+++ b/api/src/main/java/com/swm/lito/api/chat/adapter/in/web/ChatController.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.chat.adapter.in.presentation;
+package com.swm.lito.api.chat.adapter.in.web;
 
 import com.swm.lito.api.chat.adapter.in.request.ChatGPTCompletionRequest;
 import com.swm.lito.api.chat.adapter.in.response.ChatGPTCompletionResponse;

--- a/api/src/main/java/com/swm/lito/api/file/adapter/in/web/FileController.java
+++ b/api/src/main/java/com/swm/lito/api/file/adapter/in/web/FileController.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.file.adapter.in.presentation;
+package com.swm.lito.api.file.adapter.in.web;
 
 import com.swm.lito.core.common.security.AuthUser;
 import com.swm.lito.core.file.application.port.in.FileUseCase;

--- a/api/src/main/java/com/swm/lito/api/problem/adapter/in/web/ProblemController.java
+++ b/api/src/main/java/com/swm/lito/api/problem/adapter/in/web/ProblemController.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.problem.adapter.in.presentation;
+package com.swm.lito.api.problem.adapter.in.web;
 
 import com.swm.lito.api.problem.adapter.in.response.*;
 import com.swm.lito.core.common.security.AuthUser;

--- a/api/src/main/java/com/swm/lito/api/user/adapter/in/web/UserController.java
+++ b/api/src/main/java/com/swm/lito/api/user/adapter/in/web/UserController.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.user.adapter.in.presentation;
+package com.swm.lito.api.user.adapter.in.web;
 
 import com.swm.lito.core.common.security.AuthUser;
 import com.swm.lito.api.user.adapter.in.request.UserRequest;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -35,6 +35,9 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+    mongodb:
+      uri: ${MONGO_DB_URI}
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}
@@ -66,6 +69,9 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
+    mongodb:
+      uri: ${DEV_MONGO_DB_URI}
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/api/src/test/java/com/swm/lito/api/auth/adapter/in/web/AuthControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/auth/adapter/in/web/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.auth.adapter.in.presentation;
+package com.swm.lito.api.auth.adapter.in.web;
 
 import com.swm.lito.api.auth.adapter.in.request.LoginRequest;
 import com.swm.lito.core.auth.application.port.in.AuthUseCase;

--- a/api/src/test/java/com/swm/lito/api/chat/adapter/in/presentation/ChatControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/chat/adapter/in/presentation/ChatControllerTest.java
@@ -44,11 +44,11 @@ class ChatControllerTest extends RestDocsSupport {
         // given
         ChatGPTCompletionRequest request = createCompletionRequest();
         ChatGPTCompletionResponseDto responseDto = createCompletionResponseDto();
-        given(chatCommandUseCase.send(any()))
+        given(chatCommandUseCase.send(any(), any(), any()))
                 .willReturn(responseDto);
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/chat-gpt")
+                post("/api/v1/chat-gpt/{problemId}", 1L)
                         .header(HttpHeaders.AUTHORIZATION,"Bearer testAccessToken")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))

--- a/api/src/test/java/com/swm/lito/api/chat/adapter/in/presentation/ChatControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/chat/adapter/in/presentation/ChatControllerTest.java
@@ -1,0 +1,135 @@
+package com.swm.lito.api.chat.adapter.in.presentation;
+
+
+import com.swm.lito.api.chat.adapter.in.request.ChatGPTCompletionRequest;
+import com.swm.lito.api.support.restdocs.RestDocsSupport;
+import com.swm.lito.api.support.security.WithMockJwt;
+import com.swm.lito.core.chat.application.port.in.ChatCommandUseCase;
+import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static com.swm.lito.api.support.restdocs.RestDocsConfig.field;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@WithMockJwt
+class ChatControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private ChatCommandUseCase chatCommandUseCase;
+
+    @Test
+    @DisplayName("chat-gpt 질문하기 성공")
+    void send_success() throws Exception {
+
+        // given
+        ChatGPTCompletionRequest request = createCompletionRequest();
+        ChatGPTCompletionResponseDto responseDto = createCompletionResponseDto();
+        given(chatCommandUseCase.send(any()))
+                .willReturn(responseDto);
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/chat-gpt")
+                        .header(HttpHeaders.AUTHORIZATION,"Bearer testAccessToken")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id",is("chatcmpl-7j05y1QjDWTsAqsRipw7tfJ4nPqsB")))
+                .andExpect(jsonPath("$.object",is("chat.completion")))
+                .andExpect(jsonPath("$.created",is(1690959482)))
+                .andExpect(jsonPath("$.model",is("gpt-3.5-turbo-0613")))
+                .andExpect(jsonPath("$.messages[0].role",is("assistant")))
+                .andExpect(jsonPath("$.messages[0].message",is("응답 메세지")))
+                .andExpect(jsonPath("$.usage.promptTokens",is(13)))
+                .andExpect(jsonPath("$.usage.completionTokens",is(44)))
+                .andExpect(jsonPath("$.usage.totalTokens",is(57)))
+
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("JWT Access Token").attributes(field("constraints", "JWT Access Token With Bearer"))
+                        ),
+                        requestFields(
+                                fieldWithPath("model").type(JsonFieldType.STRING).description("gpt-3.5-turbo 고정"),
+                                fieldWithPath("role").type(JsonFieldType.STRING).description("user 고정"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("질문 메세지"),
+                                fieldWithPath("maxTokens").type(JsonFieldType.NUMBER).description("prompt와 completion에 사용되는 토큰의 합 최대치")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.STRING).description("chat unique id"),
+                                fieldWithPath("object").type(JsonFieldType.STRING).description("chat.completion"),
+                                fieldWithPath("created").type(JsonFieldType.NUMBER).description("생성된 유닉스 시간"),
+                                fieldWithPath("model").type(JsonFieldType.STRING).description("사용한 chat-gpt 모델"),
+                                fieldWithPath("messages[].role").type(JsonFieldType.STRING).description("assistant값 고정(대답을 해주는 챗봇 이라는 의미)"),
+                                fieldWithPath("messages[].message").type(JsonFieldType.STRING).description("chat-gpt 응답 메세지"),
+                                fieldWithPath("usage.promptTokens").type(JsonFieldType.NUMBER).description("prompt token 사용량"),
+                                fieldWithPath("usage.completionTokens").type(JsonFieldType.NUMBER).description("completion token 사용량(메세지)"),
+                                fieldWithPath("usage.totalTokens").type(JsonFieldType.NUMBER).description("prompt tokens + completion tokens")
+                        )
+                ));
+    }
+
+    private static ChatGPTCompletionRequest createCompletionRequest(){
+        return ChatGPTCompletionRequest.builder()
+                .model("gpt-3.5-turbo")
+                .role("user")
+                .message("질문 메세지")
+                .maxTokens(1000)
+                .build();
+
+
+    }
+
+    private static ChatGPTCompletionResponseDto createCompletionResponseDto(){
+        return ChatGPTCompletionResponseDto.builder()
+                .id("chatcmpl-7j05y1QjDWTsAqsRipw7tfJ4nPqsB")
+                .object("chat.completion")
+                .created(1690959482L)
+                .model("gpt-3.5-turbo-0613")
+                .messages(createMessages())
+                .usage(createResponseDtoUsage())
+                .build();
+    }
+
+    private static List<ChatGPTCompletionResponseDto.Message> createMessages(){
+        return List.of(createMessage());
+    }
+
+    private static ChatGPTCompletionResponseDto.Message createMessage(){
+        return ChatGPTCompletionResponseDto.Message.builder()
+                .role("assistant")
+                .message("응답 메세지")
+                .build();
+
+    }
+
+    private static ChatGPTCompletionResponseDto.Usage createResponseDtoUsage(){
+        return ChatGPTCompletionResponseDto.Usage.builder()
+                .promptTokens(13L)
+                .completionTokens(44L)
+                .totalTokens(57L)
+                .build();
+    }
+
+}

--- a/api/src/test/java/com/swm/lito/api/chat/adapter/in/web/ChatControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/chat/adapter/in/web/ChatControllerTest.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.chat.adapter.in.presentation;
+package com.swm.lito.api.chat.adapter.in.web;
 
 
 import com.swm.lito.api.chat.adapter.in.request.ChatGPTCompletionRequest;

--- a/api/src/test/java/com/swm/lito/api/chat/adapter/in/web/ChatControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/chat/adapter/in/web/ChatControllerTest.java
@@ -71,10 +71,7 @@ class ChatControllerTest extends RestDocsSupport {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("JWT Access Token").attributes(field("constraints", "JWT Access Token With Bearer"))
                         ),
                         requestFields(
-                                fieldWithPath("model").type(JsonFieldType.STRING).description("gpt-3.5-turbo 고정"),
-                                fieldWithPath("role").type(JsonFieldType.STRING).description("user 고정"),
-                                fieldWithPath("message").type(JsonFieldType.STRING).description("질문 메세지"),
-                                fieldWithPath("maxTokens").type(JsonFieldType.NUMBER).description("prompt와 completion에 사용되는 토큰의 합 최대치")
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("질문 메세지")
                         ),
                         responseFields(
                                 fieldWithPath("id").type(JsonFieldType.STRING).description("chat unique id"),
@@ -92,13 +89,8 @@ class ChatControllerTest extends RestDocsSupport {
 
     private static ChatGPTCompletionRequest createCompletionRequest(){
         return ChatGPTCompletionRequest.builder()
-                .model("gpt-3.5-turbo")
-                .role("user")
                 .message("질문 메세지")
-                .maxTokens(1000)
                 .build();
-
-
     }
 
     private static ChatGPTCompletionResponseDto createCompletionResponseDto(){

--- a/api/src/test/java/com/swm/lito/api/file/adapter/in/web/FileControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/file/adapter/in/web/FileControllerTest.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.file.adapter.in.presentation;
+package com.swm.lito.api.file.adapter.in.web;
 
 import com.swm.lito.core.common.exception.ApplicationException;
 import com.swm.lito.core.common.exception.file.FileErrorCode;

--- a/api/src/test/java/com/swm/lito/api/problem/adapter/in/web/ProblemControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/problem/adapter/in/web/ProblemControllerTest.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.problem.adapter.in.presentation;
+package com.swm.lito.api.problem.adapter.in.web;
 
 import com.swm.lito.core.common.exception.ApplicationException;
 import com.swm.lito.core.common.exception.problem.ProblemErrorCode;

--- a/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
@@ -1,4 +1,4 @@
-package com.swm.lito.api.user.adapter.in.presentation;
+package com.swm.lito.api.user.adapter.in.web;
 
 import com.swm.lito.api.support.restdocs.RestDocsSupport;
 import com.swm.lito.api.support.security.WithMockJwt;

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    //chat gpt
+    implementation 'com.theokanning.openai-gpt3-java:service:0.14.0'
+
     //querydsl 설정 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     //chat gpt
     implementation 'com.theokanning.openai-gpt3-java:service:0.14.0'
 
+    //mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     //querydsl 설정 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/core/src/main/java/com/swm/lito/core/chat/adapter/out/ChatCommandAdapter.java
+++ b/core/src/main/java/com/swm/lito/core/chat/adapter/out/ChatCommandAdapter.java
@@ -1,0 +1,18 @@
+package com.swm.lito.core.chat.adapter.out;
+
+import com.swm.lito.core.chat.application.port.ChatCommandPort;
+import com.swm.lito.core.chat.domain.Chat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatCommandAdapter implements ChatCommandPort {
+
+    private final ChatRepository chatRepository;
+
+    @Override
+    public void save(Chat chat) {
+        chatRepository.save(chat);
+    }
+}

--- a/core/src/main/java/com/swm/lito/core/chat/adapter/out/ChatRepository.java
+++ b/core/src/main/java/com/swm/lito/core/chat/adapter/out/ChatRepository.java
@@ -1,0 +1,8 @@
+package com.swm.lito.core.chat.adapter.out;
+
+import com.swm.lito.core.chat.domain.Chat;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+
+public interface ChatRepository extends MongoRepository<Chat, String> {
+}

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/ChatCommandPort.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/ChatCommandPort.java
@@ -1,0 +1,8 @@
+package com.swm.lito.core.chat.application.port;
+
+import com.swm.lito.core.chat.domain.Chat;
+
+public interface ChatCommandPort {
+
+    void save(Chat chat);
+}

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/in/ChatCommandUseCase.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/in/ChatCommandUseCase.java
@@ -1,0 +1,9 @@
+package com.swm.lito.core.chat.application.port.in;
+
+import com.swm.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
+import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
+
+public interface ChatCommandUseCase {
+
+    ChatGPTCompletionResponseDto send(ChatGPTCompletionRequestDto requestDto);
+}

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/in/ChatCommandUseCase.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/in/ChatCommandUseCase.java
@@ -2,8 +2,9 @@ package com.swm.lito.core.chat.application.port.in;
 
 import com.swm.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
 import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
+import com.swm.lito.core.common.security.AuthUser;
 
 public interface ChatCommandUseCase {
 
-    ChatGPTCompletionResponseDto send(ChatGPTCompletionRequestDto requestDto);
+    ChatGPTCompletionResponseDto send(AuthUser authUser, Long problemId, ChatGPTCompletionRequestDto requestDto);
 }

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/in/request/ChatGPTCompletionRequestDto.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/in/request/ChatGPTCompletionRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -32,6 +33,9 @@ public class ChatGPTCompletionRequestDto {
     }
 
     private static List<ChatMessage> convertChatMessage(ChatGPTCompletionRequestDto request) {
-        return List.of(new ChatMessage(request.getRole(), request.getMessage()));
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new ChatMessage("system", "너는 IT 전문가로서 행동하고 대답해야한다."));
+        chatMessages.add(new ChatMessage(request.getRole(), request.getMessage()));
+        return chatMessages;
     }
 }

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/in/request/ChatGPTCompletionRequestDto.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/in/request/ChatGPTCompletionRequestDto.java
@@ -1,0 +1,37 @@
+package com.swm.lito.core.chat.application.port.in.request;
+
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatGPTCompletionRequestDto {
+
+    private String model;
+
+    private String role;
+
+    private String message;
+
+    private Integer maxTokens;
+
+    public static ChatCompletionRequest from(ChatGPTCompletionRequestDto request) {
+        return ChatCompletionRequest.builder()
+                .model(request.getModel())
+                .messages(convertChatMessage(request))
+                .maxTokens(request.getMaxTokens())
+                .build();
+    }
+
+    private static List<ChatMessage> convertChatMessage(ChatGPTCompletionRequestDto request) {
+        return List.of(new ChatMessage(request.getRole(), request.getMessage()));
+    }
+}

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/in/request/ChatGPTCompletionRequestDto.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/in/request/ChatGPTCompletionRequestDto.java
@@ -1,14 +1,9 @@
 package com.swm.lito.core.chat.application.port.in.request;
 
-import com.theokanning.openai.completion.chat.ChatCompletionRequest;
-import com.theokanning.openai.completion.chat.ChatMessage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -22,20 +17,18 @@ public class ChatGPTCompletionRequestDto {
 
     private String message;
 
-    private Integer maxTokens;
-
-    public static ChatCompletionRequest from(ChatGPTCompletionRequestDto request) {
-        return ChatCompletionRequest.builder()
-                .model(request.getModel())
-                .messages(convertChatMessage(request))
-                .maxTokens(request.getMaxTokens())
+    public static ChatGPTCompletionRequestDto from(String message){
+        return ChatGPTCompletionRequestDto.builder()
+                .message(message)
                 .build();
     }
 
-    private static List<ChatMessage> convertChatMessage(ChatGPTCompletionRequestDto request) {
-        List<ChatMessage> chatMessages = new ArrayList<>();
-        chatMessages.add(new ChatMessage("system", "너는 IT 전문가로서 행동하고 대답해야한다."));
-        chatMessages.add(new ChatMessage(request.getRole(), request.getMessage()));
-        return chatMessages;
+    public static ChatGPTCompletionRequestDto from(String model, String role, String message){
+        return ChatGPTCompletionRequestDto.builder()
+                .model(model)
+                .role(role)
+                .message(message)
+                .build();
     }
+
 }

--- a/core/src/main/java/com/swm/lito/core/chat/application/port/in/response/ChatGPTCompletionResponseDto.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/port/in/response/ChatGPTCompletionResponseDto.java
@@ -1,0 +1,88 @@
+package com.swm.lito.core.chat.application.port.in.response;
+
+import com.theokanning.openai.completion.chat.ChatCompletionChoice;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatGPTCompletionResponseDto {
+
+    private String id;
+
+    private String object;
+
+    private Long created;
+
+    private String model;
+
+    private List<Message> messages;
+
+    private Usage usage;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Message {
+
+        private String role;
+
+        private String message;
+
+        public static Message from(ChatMessage chatMessage) {
+            return Message.builder()
+                    .message(chatMessage.getRole())
+                    .message(chatMessage.getContent())
+                    .build();
+        }
+    }
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Usage {
+
+        private Long promptTokens;
+
+        private Long completionTokens;
+
+        private Long totalTokens;
+
+        public static Usage from(com.theokanning.openai.Usage usage) {
+            return Usage.builder()
+                    .promptTokens(usage.getPromptTokens())
+                    .completionTokens(usage.getCompletionTokens())
+                    .totalTokens(usage.getTotalTokens())
+                    .build();
+        }
+    }
+
+    public static List<Message> toResponseDtoMessages(List<ChatCompletionChoice> choices) {
+        return choices.stream()
+                .map(completionChoice -> Message.from(completionChoice.getMessage()))
+                .collect(Collectors.toList());
+    }
+
+    public static ChatGPTCompletionResponseDto from(ChatCompletionResult result) {
+        return ChatGPTCompletionResponseDto.builder()
+                .id(result.getId())
+                .object(result.getObject())
+                .created(result.getCreated())
+                .model(result.getModel())
+                .messages(toResponseDtoMessages(result.getChoices()))
+                .usage(Usage.from(result.getUsage()))
+                .build();
+    }
+}

--- a/core/src/main/java/com/swm/lito/core/chat/application/service/ChatCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/service/ChatCommandService.java
@@ -5,11 +5,21 @@ import com.swm.lito.core.chat.application.port.in.ChatCommandUseCase;
 import com.swm.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
 import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
 import com.swm.lito.core.chat.domain.Chat;
+import com.swm.lito.core.common.exception.ApplicationException;
+import com.swm.lito.core.common.exception.problem.ProblemErrorCode;
 import com.swm.lito.core.common.security.AuthUser;
+import com.swm.lito.core.problem.application.port.out.ProblemQueryPort;
+import com.swm.lito.core.problem.domain.Problem;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,18 +27,41 @@ public class ChatCommandService implements ChatCommandUseCase {
 
     private final OpenAiService openAiService;
     private final ChatCommandPort chatCommandPort;
+    private final ProblemQueryPort problemQueryPort;
+
+    @Value("${chat-gpt.model}")
+    private String model;
+
+    @Value("${chat-gpt.role}")
+    private String role;
 
     @Override
     public ChatGPTCompletionResponseDto send(AuthUser authUser, Long problemId, ChatGPTCompletionRequestDto requestDto){
+        Problem problem = problemQueryPort.findProblemById(problemId)
+                .orElseThrow(() -> new ApplicationException(ProblemErrorCode.PROBLEM_NOT_FOUND));
         ChatCompletionResult chatCompletion = openAiService.createChatCompletion(
-                ChatGPTCompletionRequestDto.from(requestDto));
+                createChatCompletion(requestDto,problem));
 
         ChatGPTCompletionResponseDto responseDto = ChatGPTCompletionResponseDto.from(chatCompletion);
 
-        //유저 번호, 문제 번호 까지 합쳐서 저장
         chatCommandPort.save(Chat.of(authUser.getUserId(), problemId, requestDto.getMessage(),
                 responseDto.getMessages().get(0).getMessage()));
         return responseDto;
+    }
+
+    private ChatCompletionRequest createChatCompletion(ChatGPTCompletionRequestDto requestDto, Problem problem){
+        return ChatCompletionRequest.builder()
+                .model(model)
+                .messages(convertChatMessage(requestDto, problem))
+                .build();
+    }
+
+    private List<ChatMessage> convertChatMessage(ChatGPTCompletionRequestDto requestDto, Problem problem) {
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        chatMessages.add(new ChatMessage("system", "유저가 " + problem.getQuestion() + " 라는 질문에 " +
+                problem.getAnswer() + " 라고 답을 한 상황이다. " + "앞으로 유저가 질문할 때 이 상황을 기반으로 너는 IT 전문가로서 5줄 이내로 대답을 해야한다."));
+        chatMessages.add(new ChatMessage(role, requestDto.getMessage()));
+        return chatMessages;
     }
 
 

--- a/core/src/main/java/com/swm/lito/core/chat/application/service/ChatCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/service/ChatCommandService.java
@@ -1,0 +1,30 @@
+package com.swm.lito.core.chat.application.service;
+
+import com.swm.lito.core.chat.application.port.in.ChatCommandUseCase;
+import com.swm.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
+import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.service.OpenAiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatCommandService implements ChatCommandUseCase {
+
+    private final OpenAiService openAiService;
+
+    @Override
+    public ChatGPTCompletionResponseDto send(ChatGPTCompletionRequestDto requestDto){
+        ChatCompletionResult chatCompletion = openAiService.createChatCompletion(
+                ChatGPTCompletionRequestDto.from(requestDto));
+
+        ChatGPTCompletionResponseDto responseDto = ChatGPTCompletionResponseDto.from(chatCompletion);
+
+        return responseDto;
+    }
+
+
+}

--- a/core/src/main/java/com/swm/lito/core/chat/application/service/ChatCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/chat/application/service/ChatCommandService.java
@@ -1,28 +1,33 @@
 package com.swm.lito.core.chat.application.service;
 
+import com.swm.lito.core.chat.application.port.ChatCommandPort;
 import com.swm.lito.core.chat.application.port.in.ChatCommandUseCase;
 import com.swm.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
 import com.swm.lito.core.chat.application.port.in.response.ChatGPTCompletionResponseDto;
+import com.swm.lito.core.chat.domain.Chat;
+import com.swm.lito.core.common.security.AuthUser;
 import com.theokanning.openai.completion.chat.ChatCompletionResult;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ChatCommandService implements ChatCommandUseCase {
 
     private final OpenAiService openAiService;
+    private final ChatCommandPort chatCommandPort;
 
     @Override
-    public ChatGPTCompletionResponseDto send(ChatGPTCompletionRequestDto requestDto){
+    public ChatGPTCompletionResponseDto send(AuthUser authUser, Long problemId, ChatGPTCompletionRequestDto requestDto){
         ChatCompletionResult chatCompletion = openAiService.createChatCompletion(
                 ChatGPTCompletionRequestDto.from(requestDto));
 
         ChatGPTCompletionResponseDto responseDto = ChatGPTCompletionResponseDto.from(chatCompletion);
 
+        //유저 번호, 문제 번호 까지 합쳐서 저장
+        chatCommandPort.save(Chat.of(authUser.getUserId(), problemId, requestDto.getMessage(),
+                responseDto.getMessages().get(0).getMessage()));
         return responseDto;
     }
 

--- a/core/src/main/java/com/swm/lito/core/chat/domain/Chat.java
+++ b/core/src/main/java/com/swm/lito/core/chat/domain/Chat.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Id;
 import lombok.*;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collation = "chats")
+@Document(collection = "chats")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/core/src/main/java/com/swm/lito/core/chat/domain/Chat.java
+++ b/core/src/main/java/com/swm/lito/core/chat/domain/Chat.java
@@ -1,0 +1,35 @@
+package com.swm.lito.core.chat.domain;
+
+import com.swm.lito.core.common.entity.BaseEntity;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collation = "chats")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Chat extends BaseEntity {
+
+    @Id
+    private String id;
+
+    private Long userId;
+
+    private Long problemId;
+
+    private String question;
+
+    private String answer;
+
+    public static Chat of(Long userId, Long problemId, String question, String answer){
+        return Chat.builder()
+                .userId(userId)
+                .problemId(problemId)
+                .question(question)
+                .answer(answer)
+                .build();
+    }
+
+}

--- a/core/src/main/java/com/swm/lito/core/config/ChatGPTConfig.java
+++ b/core/src/main/java/com/swm/lito/core/config/ChatGPTConfig.java
@@ -1,0 +1,21 @@
+package com.swm.lito.core.config;
+
+import com.theokanning.openai.service.OpenAiService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class ChatGPTConfig {
+
+    @Value("${chat-gpt.api-key}")
+    private String apiKey;
+
+    @Bean
+    public OpenAiService openAiService(){
+        return new OpenAiService(apiKey, Duration.ofSeconds(60));
+    }
+
+}

--- a/core/src/main/java/com/swm/lito/core/config/JpaAuditingConfig.java
+++ b/core/src/main/java/com/swm/lito/core/config/JpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package com.swm.lito.core.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@EnableJpaAuditing
-@Configuration
-public class JpaAuditingConfig {
-}

--- a/core/src/main/java/com/swm/lito/core/config/JpaConfig.java
+++ b/core/src/main/java/com/swm/lito/core/config/JpaConfig.java
@@ -1,0 +1,15 @@
+package com.swm.lito.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackages = {
+        "com.swm.lito.core.company",
+        "com.swm.lito.core.problem",
+        "com.swm.lito.core.user",
+})
+public class JpaConfig {
+}

--- a/core/src/main/java/com/swm/lito/core/config/MongoConfig.java
+++ b/core/src/main/java/com/swm/lito/core/config/MongoConfig.java
@@ -1,0 +1,11 @@
+package com.swm.lito.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoAuditing
+@EnableMongoRepositories("com.swm.lito.core.chat")
+public class MongoConfig {
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   profiles:
     active: local
 
+chat-gpt:
+  api-key: ${CHAT_GPT_API_KEY}
+
 cloud:
   aws:
     credentials:

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
 
 chat-gpt:
   api-key: ${CHAT_GPT_API_KEY}
+  model: ${CHAT_GPT_MODEL}
+  role: ${CHAT_GPT_ROLE}
 
 cloud:
   aws:
@@ -68,6 +70,9 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
+    mongodb:
+      uri: ${DEV_MONGO_DB_URI}
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -34,6 +34,9 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+    mongodb:
+      uri: ${MONGO_DB_URI}
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}
@@ -44,17 +47,17 @@ spring:
     open-in-view: false
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         show_sql: true
         format_sql: true
-#    defer-datasource-initialization: true
+    defer-datasource-initialization: true
   sql:
     init:
-      mode: never
+      mode: always
 ---
 spring:
   config:


### PR DESCRIPTION
## 작업내용
- chat-gpt 로직 구현
- mongodb 연결 및 documents 생성( 개발 서버는 mongodb atlas 이용)
- chat-gpt prompt 엔지니어링 적용