### PR TITLE
[LITO-157] chore: 멀티 모듈 환경에서 개발 환경 분리 및 의존성 개선

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,28 +1,11 @@
 spring:
   profiles:
     active: local
+    include: core
 
   servlet:
     multipart:
       max-file-size: 10MB
-
-cloud:
-  aws:
-    credentials:
-      access-key: ${S3_ACCESS_KEY}
-      secret-key: ${S3_SECRET_KEY}
-    s3:
-      bucket: ${S3_BUCKET}
-      file-path: ${S3_FILEPATH}
-    region:
-      static: ${S3_REGION}
-    stack:
-      auto: false
-jwt:
-  secret: ${SECRET_KEY}
-  access-expiration-time: ${ACCESS_EXPIRED_TIME}
-  refresh-expiration-time: ${REFRESH_EXPIRED_TIME}
-  refresh-valid-time: ${REFRESH_VALID_TIME}
 
 ---
 spring:
@@ -30,66 +13,8 @@ spring:
     activate:
       on-profile: local
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
-    mongodb:
-      uri: ${MONGO_DB_URI}
-
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-
-  jpa:
-    open-in-view: false
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-#    defer-datasource-initialization: true
-  sql:
-    init:
-      mode: never
 ---
 spring:
   config:
     activate:
       on-profile: dev
-
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
-    mongodb:
-      uri: ${DEV_MONGO_DB_URI}
-
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DEV_DB_URL}
-    username: ${DEV_DB_USERNAME}
-    password: ${DEV_DB_PASSWORD}
-
-  jpa:
-    open-in-view: false
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-  sql:
-    init:
-      mode: never

--- a/batch/src/main/java/com/swm/lito/batch/job/ProblemUserJobConfig.java
+++ b/batch/src/main/java/com/swm/lito/batch/job/ProblemUserJobConfig.java
@@ -1,12 +1,12 @@
 package com.swm.lito.batch.job;
 
-import com.swm.lito.batch.domain.Batch;
-import com.swm.lito.batch.domain.BatchRepository;
 import com.swm.lito.batch.dto.request.ProblemUserRequest;
 import com.swm.lito.batch.dto.request.ProblemUserRequestDto;
 import com.swm.lito.batch.dto.response.ProblemUserResponse;
+import com.swm.lito.core.problem.adapter.out.persistence.BatchRepository;
 import com.swm.lito.core.problem.adapter.out.persistence.ProblemRepository;
 import com.swm.lito.core.problem.adapter.out.persistence.ProblemUserRepository;
+import com.swm.lito.core.problem.domain.Batch;
 import com.swm.lito.core.problem.domain.Problem;
 import com.swm.lito.core.problem.domain.ProblemUser;
 import com.swm.lito.core.user.adapter.out.persistence.UserRepository;

--- a/batch/src/main/java/com/swm/lito/batch/job/RecommendUserJobConfig.java
+++ b/batch/src/main/java/com/swm/lito/batch/job/RecommendUserJobConfig.java
@@ -1,11 +1,11 @@
 package com.swm.lito.batch.job;
 
-import com.swm.lito.batch.domain.Batch;
-import com.swm.lito.batch.domain.BatchRepository;
 import com.swm.lito.batch.dto.response.RecommendUserResponse;
 import com.swm.lito.core.common.exception.ApplicationException;
 import com.swm.lito.core.common.exception.batch.BatchErrorCode;
+import com.swm.lito.core.problem.adapter.out.persistence.BatchRepository;
 import com.swm.lito.core.problem.adapter.out.persistence.RecommendUserRepository;
+import com.swm.lito.core.problem.domain.Batch;
 import com.swm.lito.core.problem.domain.RecommendUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: local
+    include: core
 
   batch:
     job:
@@ -11,87 +12,20 @@ spring:
 server:
   port: 8081
 
-ml-server:
-  url: ${ML_SERVER_URL}
-
-cloud:
-  aws:
-    credentials:
-      access-key: ${S3_ACCESS_KEY}
-      secret-key: ${S3_SECRET_KEY}
-    s3:
-      bucket: ${S3_BUCKET}
-      file-path: ${S3_FILEPATH}
-    region:
-      static: ${S3_REGION}
-    stack:
-      auto: false
-jwt:
-  secret: ${SECRET_KEY}
-  access-expiration-time: ${ACCESS_EXPIRED_TIME}
-  refresh-expiration-time: ${REFRESH_EXPIRED_TIME}
-  refresh-valid-time: ${REFRESH_VALID_TIME}
-
 ---
 spring:
   config:
     activate:
       on-profile: local
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+ml-server:
+  url: ${ML_SERVER_URL}
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-
-  jpa:
-    open-in-view: false
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-#    defer-datasource-initialization: true
-  sql:
-    init:
-      mode: never
 ---
 spring:
   config:
     activate:
       on-profile: dev
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DEV_DB_URL}
-    username: ${DEV_DB_USERNAME}
-    password: ${DEV_DB_PASSWORD}
-
-  jpa:
-    open-in-view: false
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: validate
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-  sql:
-    init:
-      mode: never
+ml-server:
+  url: ${DEV_ML_SERVER_URL}

--- a/core/src/main/java/com/swm/lito/core/problem/adapter/out/persistence/BatchRepository.java
+++ b/core/src/main/java/com/swm/lito/core/problem/adapter/out/persistence/BatchRepository.java
@@ -1,5 +1,6 @@
-package com.swm.lito.batch.domain;
+package com.swm.lito.core.problem.adapter.out.persistence;
 
+import com.swm.lito.core.problem.domain.Batch;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;

--- a/core/src/main/java/com/swm/lito/core/problem/domain/Batch.java
+++ b/core/src/main/java/com/swm/lito/core/problem/domain/Batch.java
@@ -1,4 +1,4 @@
-package com.swm.lito.batch.domain;
+package com.swm.lito.core.problem.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -1,7 +1,3 @@
-spring:
-  profiles:
-    active: local
-
 chat-gpt:
   api-key: ${CHAT_GPT_API_KEY}
   model: ${CHAT_GPT_MODEL}
@@ -19,6 +15,7 @@ cloud:
       static: ${S3_REGION}
     stack:
       auto: false
+
 jwt:
   secret: ${SECRET_KEY}
   access-expiration-time: ${ACCESS_EXPIRED_TIME}
@@ -30,7 +27,6 @@ spring:
   config:
     activate:
       on-profile: local
-
   data:
     redis:
       host: ${REDIS_HOST}
@@ -60,6 +56,7 @@ spring:
   sql:
     init:
       mode: always
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 작업내용
- core 모듈을 통해 다른 모듈에서 사용하는 공통 환경 변수 중복 제거
- 개발환경 분리에 따른 redis, mysql, mongodb, jpa 분리 및 core 모듈에서 관리를 통한 중복 제거

## 기대효과
- 동일한 코드의 반복을 제거함으로써 잠재적인 버그의 위협 사전 차단
- 반복되는 코드로 인한 유지 보수의 오버헤드 감소