### PR TITLE
[LITO-165] chore: batch서버 불필요한 저장소 설정 제거

### DIFF
--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
   config:
     activate:
       on-profile: local
+  data:
+    redis:
+      host: localhost
+      port: 6370
 
 ml-server:
   url: ${ML_SERVER_URL}
@@ -26,6 +30,14 @@ spring:
   config:
     activate:
       on-profile: dev
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+    mongodb:
+      uri: ${DEV_MONGO_DB_URI}
 
 ml-server:
   url: ${DEV_ML_SERVER_URL}

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -32,9 +32,6 @@ spring:
     redis:
       host: localhost
       port: 6370
-    mongodb:
-      host: localhost
-      port: 27010
 
   datasource:
     url: jdbc:h2:mem:~/lito


### PR DESCRIPTION
## 작업내용
- batch 서버에서는 redis와 mongodb를 사용안하므로 임베디드 환경으로 변경