### PR TITLE
[LITO-168] feat: 회원 탈퇴

### DIFF
--- a/api/src/docs/asciidoc/user.adoc
+++ b/api/src/docs/asciidoc/user.adoc
@@ -60,3 +60,17 @@ include::{snippets}/user-controller-test/update_notification_success/http-respon
 === U001
 include::{snippets}/user-controller-test/update_notification_fail_not_found/http-request.adoc[]
 include::{snippets}/user-controller-test/update_notification_fail_not_found/http-response.adoc[]
+
+== 회원 탈퇴
+
+=== 요청
+include::{snippets}/user-controller-test/delete_user_success/http-request.adoc[]
+include::{snippets}/user-controller-test/delete_user_success/request-headers.adoc[]
+
+=== 응답
+include::{snippets}/user-controller-test/delete_user_fail_not_found/http-response.adoc[]
+
+== U001
+include::{snippets}/user-controller-test/delete_user_fail_not_found/http-request.adoc[]
+include::{snippets}/user-controller-test/delete_user_fail_not_found/http-response.adoc[]
+

--- a/api/src/docs/asciidoc/user.adoc
+++ b/api/src/docs/asciidoc/user.adoc
@@ -39,10 +39,6 @@ include::{snippets}/user-controller-test/update_user_fail_not_found/http-respons
 include::{snippets}/user-controller-test/update_user_fail_existed_nickname/http-request.adoc[]
 include::{snippets}/user-controller-test/update_user_fail_existed_nickname/http-response.adoc[]
 
-=== U003
-include::{snippets}/user-controller-test/update_user_fail_user_invalid/http-request.adoc[]
-include::{snippets}/user-controller-test/update_user_fail_user_invalid/http-response.adoc[]
-
 === V001
 include::{snippets}/user-controller-test/update_user_fail_not_valid/http-request.adoc[]
 include::{snippets}/user-controller-test/update_user_fail_not_valid/http-response.adoc[]

--- a/api/src/main/java/com/swm/lito/api/user/adapter/in/web/UserController.java
+++ b/api/src/main/java/com/swm/lito/api/user/adapter/in/web/UserController.java
@@ -33,4 +33,9 @@ public class UserController {
                                    @RequestParam String alarmStatus){
         userCommandUseCase.updateNotification(authUser,alarmStatus);
     }
+
+    @DeleteMapping
+    public void delete(@AuthenticationPrincipal AuthUser authUser){
+        userCommandUseCase.delete(authUser);
+    }
 }

--- a/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
@@ -25,8 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -287,6 +286,47 @@ public class UserControllerTest extends RestDocsSupport {
 
         );
         //then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code",is(USER_NOT_FOUND.getCode())))
+                .andExpect(jsonPath("$.message",is(USER_NOT_FOUND.getMessage())));
+    }
+
+    @Test
+    @DisplayName("유저 삭제 성공")
+    void delete_user_success() throws Exception {
+
+        // given
+        willDoNothing().given(userCommandUseCase).delete(any());
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION,"Bearer testAccessToken")
+
+        );
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("JWT Access Token").attributes(field("constraints", "JWT Access Token With Bearer"))
+                        )));
+    }
+
+    @Test
+    @DisplayName("유저 삭제 실패 / 존재하지 않는 유저")
+    void delete_user_fail_not_found() throws Exception {
+
+        // given
+        willThrow(new ApplicationException(USER_NOT_FOUND))
+                .given(userCommandUseCase).delete(any());
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/users")
+                        .header(HttpHeaders.AUTHORIZATION,"Bearer testAccessToken")
+
+        );
+        // then
         resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code",is(USER_NOT_FOUND.getCode())))

--- a/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
@@ -170,31 +170,6 @@ public class UserControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.message",is(USER_NOT_FOUND.getMessage())));
     }
 
-    @Test
-    @DisplayName("유저 프로필 수정 실패 / 권한이 없는 유저")
-    void update_user_fail_user_invalid() throws Exception {
-
-        //given
-        UserRequest request = UserRequest.builder()
-                .nickname("닉네임")
-                .introduce("소개")
-                .name("이름")
-                .build();
-        willThrow(new ApplicationException(USER_INVALID))
-                .given(userCommandUseCase).update(any(),any());
-        //when
-        ResultActions resultActions = mockMvc.perform(
-                patch("/api/v1/users")
-                        .header(HttpHeaders.AUTHORIZATION,"Bearer testAccessToken")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-        );
-        //then
-        resultActions
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code",is(USER_INVALID.getCode())))
-                .andExpect(jsonPath("$.message",is(USER_INVALID.getMessage())));
-    }
 
     @Test
     @DisplayName("유저 프로필 수정 실패 / 이미 존재하는 닉네임")

--- a/core/src/main/java/com/swm/lito/core/user/application/port/in/UserCommandUseCase.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/port/in/UserCommandUseCase.java
@@ -7,4 +7,6 @@ public interface UserCommandUseCase {
 
     void update(AuthUser authUser, UserRequestDto userRequestDto);
     void updateNotification(AuthUser authUser, String alarmStatus);
+
+    void delete(AuthUser authUser);
 }

--- a/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
@@ -37,4 +37,11 @@ public class UserCommandService implements UserCommandUseCase {
         user.changeNotification(alarmStatus);
 
     }
+
+    @Override
+    public void delete(AuthUser authUser) {
+        User user = userQueryPort.findById(authUser.getUserId())
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.USER_NOT_FOUND));
+        user.deleteUser();
+    }
 }

--- a/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
@@ -26,7 +26,6 @@ public class UserCommandService implements UserCommandUseCase {
                 .ifPresent(findUser -> {
                     throw new ApplicationException(UserErrorCode.USER_EXISTED_NICKNAME);
                 });
-        user.validateUser(authUser, user);
         user.change(userRequestDto);
     }
 

--- a/core/src/main/java/com/swm/lito/core/user/domain/User.java
+++ b/core/src/main/java/com/swm/lito/core/user/domain/User.java
@@ -106,5 +106,9 @@ public class User extends BaseEntity {
         }
     }
 
+    public void deleteUser(){
+        changeStatus(Status.INACTIVE);
+    }
+
 
 }

--- a/core/src/main/java/com/swm/lito/core/user/domain/User.java
+++ b/core/src/main/java/com/swm/lito/core/user/domain/User.java
@@ -62,13 +62,6 @@ public class User extends BaseEntity {
     @Column(name = "profile_img_url", columnDefinition = "TEXT")
     private String profileImgUrl;
 
-
-    public void validateUser(AuthUser authUser, User user) {
-        if(!Objects.equals(authUser.getUserId(), user.getId())){
-            throw new ApplicationException(UserErrorCode.USER_INVALID);
-        }
-    }
-
     public void change(UserRequestDto userRequestDto){
         changeNickname(userRequestDto.getNickname());
         changeIntroduce(userRequestDto.getIntroduce());


### PR DESCRIPTION
## 작업내용
- 회원 탈퇴 기능
- 프로필 수정 로직에서 validateUser 메서드 불필요하다 판단
    - 이유: security context holder를 통해 로그인이 완료된 유저의 userId를 가져오고, 이 값을 기반으로 유저 엔티티를 조회하므로, 이미 이 부분에서 검증이 완료가 됐기 때문이다.