### PR TITLE
[LITO-175] feat: 최초 가입시 프로필 생성

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,28 +32,6 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew clean :api:build
-        env:
-          CHAT_GPT_API_KEY: ${{ secrets.CHAT_GPT_API_KEY }}
-          CHAT_GPT_MODEL: ${{ secrets.CHAT_GPT_MODEL }}
-          CHAT_GPT_ROLE: ${{ secrets.CHAT_GPT_ROLE }}
-          REDIS_HOST: ${{ secrets.REDIS_HOST }}
-          REDIS_PORT: ${{ secrets.REDIS_PORT }}
-          DB_URL: ${{ secrets.DB_URL }}
-          DB_USERNAME: ${{ secrets.DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DEV_DB_URL: ${{ secrets.DEV_DB_URL }}
-          DEV_DB_USERNAME: ${{ secrets.DEV_DB_USERNAME }}
-          DEV_DB_PASSWORD: ${{ secrets.DEV_DB_PASSWORD }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          ACCESS_EXPIRED_TIME: ${{ secrets.ACCESS_EXPIRED_TIME }}
-          REFRESH_EXPIRED_TIME: ${{ secrets.REFRESH_EXPIRED_TIME }}
-          REFRESH_VALID_TIME: ${{ secrets.REFRESH_VALID_TIME }}
-          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-          S3_REGION: ${{ secrets.S3_REGION }}
-          S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          S3_FILEPATH: ${{ secrets.S3_FILEPATH }} 
-          DEV_MONGO_DB_URI: ${{ secrets.DEV_MONGO_DB_URI }}
 
       - name: DockerHub Login
         uses: docker/login-action@v2

--- a/api/src/main/java/com/swm/lito/api/user/adapter/in/request/ProfileRequest.java
+++ b/api/src/main/java/com/swm/lito/api/user/adapter/in/request/ProfileRequest.java
@@ -1,8 +1,8 @@
 package com.swm.lito.api.user.adapter.in.request;
 
 import com.swm.lito.core.user.application.port.in.request.ProfileRequestDto;
-import com.swm.lito.core.user.application.port.in.request.UserRequestDto;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,20 +13,18 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class UserRequest {
+public class ProfileRequest {
 
-    @NotBlank(message = "닉네임을 입력해주세요.")
-    @Length(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 작성해주세요.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 작성해주세요.")
     private String nickname;
 
     private String introduce;
 
-    @NotBlank(message = "이름을 입력해주세요.")
-    @Length(min = 2, max = 10, message = "이름은 2자 이상 10자 이하로 작성해주세요.")
+    @Size(min = 2, max = 10, message = "이름은 2자 이상 10자 이하로 작성해주세요.")
     private String name;
 
-    public UserRequestDto toRequestDto(){
-        return UserRequestDto.builder()
+    public ProfileRequestDto toRequestDto(){
+        return ProfileRequestDto.builder()
                 .nickname(nickname)
                 .introduce(introduce)
                 .name(name)

--- a/api/src/main/java/com/swm/lito/api/user/adapter/in/request/ProfileRequest.java
+++ b/api/src/main/java/com/swm/lito/api/user/adapter/in/request/ProfileRequest.java
@@ -20,14 +20,10 @@ public class ProfileRequest {
 
     private String introduce;
 
-    @Size(min = 2, max = 10, message = "이름은 2자 이상 10자 이하로 작성해주세요.")
-    private String name;
-
     public ProfileRequestDto toRequestDto(){
         return ProfileRequestDto.builder()
                 .nickname(nickname)
                 .introduce(introduce)
-                .name(name)
                 .build();
     }
 }

--- a/api/src/main/java/com/swm/lito/api/user/adapter/in/web/UserController.java
+++ b/api/src/main/java/com/swm/lito/api/user/adapter/in/web/UserController.java
@@ -1,7 +1,8 @@
 package com.swm.lito.api.user.adapter.in.web;
 
-import com.swm.lito.core.common.security.AuthUser;
 import com.swm.lito.api.user.adapter.in.request.UserRequest;
+import com.swm.lito.core.common.security.AuthUser;
+import com.swm.lito.api.user.adapter.in.request.ProfileRequest;
 import com.swm.lito.api.user.adapter.in.response.UserResponse;
 import com.swm.lito.core.user.application.port.in.UserCommandUseCase;
 import com.swm.lito.core.user.application.port.in.UserQueryUseCase;
@@ -23,11 +24,18 @@ public class UserController {
         return UserResponse.from(userQueryUseCase.find(id));
     }
 
+    @PostMapping
+    public void create(@AuthenticationPrincipal AuthUser authUser,
+                       @RequestBody @Valid UserRequest userRequest){
+        userCommandUseCase.create(authUser, userRequest.toRequestDto());
+    }
+
     @PatchMapping
     public void update(@AuthenticationPrincipal AuthUser authUser,
-                       @RequestBody @Valid UserRequest userRequest){
-        userCommandUseCase.update(authUser, userRequest.toRequestDto());
+                       @RequestBody @Valid ProfileRequest profileRequest){
+        userCommandUseCase.update(authUser, profileRequest.toRequestDto());
     }
+
     @PatchMapping("/notifications")
     public void updateNotification(@AuthenticationPrincipal AuthUser authUser,
                                    @RequestParam String alarmStatus){

--- a/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
+++ b/api/src/test/java/com/swm/lito/api/user/adapter/in/web/UserControllerTest.java
@@ -113,7 +113,7 @@ public class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("최초 프로필 생성 성공")
+    @DisplayName("프로필 생성 성공")
     void create_user_success() throws Exception {
 
         //given
@@ -146,7 +146,7 @@ public class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("최초 프로필 생성 실패 / 존재하지 않는 유저")
+    @DisplayName("프로필 생성 실패 / 존재하지 않는 유저")
     void create_user_fail_not_found_user() throws Exception {
 
         //given
@@ -172,7 +172,7 @@ public class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("최초 프로필 생성 실패 / 이미 존재하는 닉네임")
+    @DisplayName("프로필 생성 실패 / 이미 존재하는 닉네임")
     void create_user_fail_existed_nickname() throws Exception {
 
         //given
@@ -198,7 +198,7 @@ public class UserControllerTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("최초 프로필 생성 실패 / 입력 조건에 대한 예외")
+    @DisplayName("프로필 생성 실패 / 입력 조건에 대한 예외")
     void create_user_fail_invalid_request() throws Exception {
 
         //given
@@ -231,7 +231,6 @@ public class UserControllerTest extends RestDocsSupport {
         ProfileRequest request = ProfileRequest.builder()
                 .nickname("닉네임")
                 .introduce("소개")
-                .name("이름")
                 .build();
         willDoNothing().given(userCommandUseCase).update(any(),any());
         //when
@@ -250,8 +249,7 @@ public class UserControllerTest extends RestDocsSupport {
                         ),
                         requestFields(
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).optional().description("변경할 닉네임"),
-                                fieldWithPath("introduce").type(JsonFieldType.STRING).optional().description("변경할 유저 소개"),
-                                fieldWithPath("name").type(JsonFieldType.STRING).optional().description("입력할 유저 이름")
+                                fieldWithPath("introduce").type(JsonFieldType.STRING).optional().description("변경할 유저 소개")
                         )
                 ));
     }
@@ -264,7 +262,6 @@ public class UserControllerTest extends RestDocsSupport {
         ProfileRequest request = ProfileRequest.builder()
                 .nickname("닉네임")
                 .introduce("소개")
-                .name("이름")
                 .build();
         willThrow(new ApplicationException(USER_NOT_FOUND))
                 .given(userCommandUseCase).update(any(),any());
@@ -291,7 +288,6 @@ public class UserControllerTest extends RestDocsSupport {
         ProfileRequest request = ProfileRequest.builder()
                 .nickname("닉네임")
                 .introduce("소개")
-                .name("이름")
                 .build();
         willThrow(new ApplicationException(USER_EXISTED_NICKNAME))
                 .given(userCommandUseCase).update(any(),any());
@@ -316,7 +312,7 @@ public class UserControllerTest extends RestDocsSupport {
         // given
         ProfileRequest request = ProfileRequest.builder()
                 .nickname("")
-                .name("")
+                .introduce("")
                 .build();
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -327,7 +323,7 @@ public class UserControllerTest extends RestDocsSupport {
         // then
         resultActions
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors",hasSize(2)));
+                .andExpect(jsonPath("$.errors",hasSize(1)));
     }
 
     @Test

--- a/core/src/main/java/com/swm/lito/core/user/application/port/in/UserCommandUseCase.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/port/in/UserCommandUseCase.java
@@ -1,11 +1,13 @@
 package com.swm.lito.core.user.application.port.in;
 
 import com.swm.lito.core.common.security.AuthUser;
+import com.swm.lito.core.user.application.port.in.request.ProfileRequestDto;
 import com.swm.lito.core.user.application.port.in.request.UserRequestDto;
 
 public interface UserCommandUseCase {
 
-    void update(AuthUser authUser, UserRequestDto userRequestDto);
+    void create(AuthUser authUser, UserRequestDto userRequestDto);
+    void update(AuthUser authUser, ProfileRequestDto profileRequestDto);
     void updateNotification(AuthUser authUser, String alarmStatus);
 
     void delete(AuthUser authUser);

--- a/core/src/main/java/com/swm/lito/core/user/application/port/in/request/ProfileRequestDto.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/port/in/request/ProfileRequestDto.java
@@ -14,6 +14,4 @@ public class ProfileRequestDto {
     private String nickname;
 
     private String introduce;
-
-    private String name;
 }

--- a/core/src/main/java/com/swm/lito/core/user/application/port/in/request/ProfileRequestDto.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/port/in/request/ProfileRequestDto.java
@@ -1,0 +1,19 @@
+package com.swm.lito.core.user.application.port.in.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileRequestDto {
+
+    private String nickname;
+
+    private String introduce;
+
+    private String name;
+}

--- a/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
@@ -4,6 +4,7 @@ import com.swm.lito.core.common.exception.ApplicationException;
 import com.swm.lito.core.common.exception.user.UserErrorCode;
 import com.swm.lito.core.common.security.AuthUser;
 import com.swm.lito.core.user.application.port.in.UserCommandUseCase;
+import com.swm.lito.core.user.application.port.in.request.ProfileRequestDto;
 import com.swm.lito.core.user.application.port.in.request.UserRequestDto;
 import com.swm.lito.core.user.application.port.out.UserQueryPort;
 import com.swm.lito.core.user.domain.User;
@@ -19,7 +20,7 @@ public class UserCommandService implements UserCommandUseCase {
     private final UserQueryPort userQueryPort;
 
     @Override
-    public void update(AuthUser authUser, UserRequestDto userRequestDto) {
+    public void create(AuthUser authUser, UserRequestDto userRequestDto){
         User user = userQueryPort.findById(authUser.getUserId())
                 .orElseThrow(() -> new ApplicationException(UserErrorCode.USER_NOT_FOUND));
         userQueryPort.findByNickname(userRequestDto.getNickname())
@@ -27,6 +28,17 @@ public class UserCommandService implements UserCommandUseCase {
                     throw new ApplicationException(UserErrorCode.USER_EXISTED_NICKNAME);
                 });
         user.change(userRequestDto);
+    }
+
+    @Override
+    public void update(AuthUser authUser, ProfileRequestDto profileRequestDto) {
+        User user = userQueryPort.findById(authUser.getUserId())
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.USER_NOT_FOUND));
+        userQueryPort.findByNickname(profileRequestDto.getNickname())
+                .ifPresent(findUser -> {
+                    throw new ApplicationException(UserErrorCode.USER_EXISTED_NICKNAME);
+                });
+        user.change(profileRequestDto);
     }
 
     @Override

--- a/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
@@ -27,7 +27,7 @@ public class UserCommandService implements UserCommandUseCase {
                 .ifPresent(findUser -> {
                     throw new ApplicationException(UserErrorCode.USER_EXISTED_NICKNAME);
                 });
-        user.change(userRequestDto);
+        user.create(userRequestDto);
     }
 
     @Override

--- a/core/src/main/java/com/swm/lito/core/user/domain/User.java
+++ b/core/src/main/java/com/swm/lito/core/user/domain/User.java
@@ -1,9 +1,7 @@
 package com.swm.lito.core.user.domain;
 
 import com.swm.lito.core.common.entity.BaseEntity;
-import com.swm.lito.core.common.exception.ApplicationException;
-import com.swm.lito.core.common.exception.user.UserErrorCode;
-import com.swm.lito.core.common.security.AuthUser;
+import com.swm.lito.core.user.application.port.in.request.ProfileRequestDto;
 import com.swm.lito.core.user.application.port.in.request.UserRequestDto;
 import com.swm.lito.core.user.domain.enums.Authority;
 import com.swm.lito.core.user.domain.enums.Provider;
@@ -12,8 +10,6 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.springframework.util.StringUtils;
-
-import java.util.Objects;
 
 @Getter
 @Entity
@@ -61,6 +57,12 @@ public class User extends BaseEntity {
 
     @Column(name = "profile_img_url", columnDefinition = "TEXT")
     private String profileImgUrl;
+
+    public void change(ProfileRequestDto profileRequestDto){
+        changeNickname(profileRequestDto.getNickname());
+        changeIntroduce(profileRequestDto.getIntroduce());
+        changeName(profileRequestDto.getName());
+    }
 
     public void change(UserRequestDto userRequestDto){
         changeNickname(userRequestDto.getNickname());

--- a/core/src/main/java/com/swm/lito/core/user/domain/User.java
+++ b/core/src/main/java/com/swm/lito/core/user/domain/User.java
@@ -61,13 +61,12 @@ public class User extends BaseEntity {
     public void change(ProfileRequestDto profileRequestDto){
         changeNickname(profileRequestDto.getNickname());
         changeIntroduce(profileRequestDto.getIntroduce());
-        changeName(profileRequestDto.getName());
     }
 
-    public void change(UserRequestDto userRequestDto){
+    public void create(UserRequestDto userRequestDto){
         changeNickname(userRequestDto.getNickname());
         changeIntroduce(userRequestDto.getIntroduce());
-        changeName(userRequestDto.getName());
+        createName(userRequestDto.getName());
     }
 
     private void changeNickname(String nickname){
@@ -83,7 +82,7 @@ public class User extends BaseEntity {
         }
     }
 
-    private void changeName(String name) {
+    private void createName(String name){
         if(StringUtils.hasText(name)){
             this.name = name;
         }


### PR DESCRIPTION
## 작업내용
- 기존: 최초 가입시 프로필 생성과 프로필 변경 API를 같이 사용
  - 변경: 최초 가입 프로필 생성과 프로필 수정 API를 분기 및 프로필 수정시 이름 필드 제거
  - 이유: 최초 가입에서는 닉네임,이름 필드에 대한 @NotBlank와 @Size validation을 적용한다면, 프로필 수정시에는 닉네임 필드에 대한 @Size 체크만 진행

- CI과정에서 환경 변수 주입 제거