### PR TITLE
[LITO-186] refactor: 프로필 변경시 nickname 필드가 null로 들어올 경우 Optional로 대응

### DIFF
--- a/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
+++ b/core/src/main/java/com/swm/lito/core/user/application/service/UserCommandService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -34,7 +36,8 @@ public class UserCommandService implements UserCommandUseCase {
     public void update(AuthUser authUser, ProfileRequestDto profileRequestDto) {
         User user = userQueryPort.findById(authUser.getUserId())
                 .orElseThrow(() -> new ApplicationException(UserErrorCode.USER_NOT_FOUND));
-        userQueryPort.findByNickname(profileRequestDto.getNickname())
+        Optional.ofNullable(profileRequestDto.getNickname())
+                .flatMap(userQueryPort::findByNickname)
                 .ifPresent(findUser -> {
                     throw new ApplicationException(UserErrorCode.USER_EXISTED_NICKNAME);
                 });


### PR DESCRIPTION
## 작업내용
- update 메서드로 유저 프로필을 변경할 때, 변경안할경우 nickname 필드가 null로 들어오고, 변경할 경우 중복 체크를 진행하므로
userQueryPort.findByNickname(userRequestDto.getNickname())을 
=> Optional.ofNullable(profileRequestDto.getNickname()) 변경

애초에 유저의 닉네임이 null인 경우가 없지만, null일 경우 불필요하게 findByNickname메서드를 실행하지 않아도 된다.