### PR TITLE
[LITO-190] refactor: batch 데이터 삽입시 jpa -> jdbc 변경

### DIFF
--- a/batch/src/main/java/com/swm/lito/batch/job/ProblemUserJobConfig.java
+++ b/batch/src/main/java/com/swm/lito/batch/job/ProblemUserJobConfig.java
@@ -12,7 +12,6 @@ import com.swm.lito.core.problem.domain.ProblemUser;
 import com.swm.lito.core.user.adapter.out.persistence.UserRepository;
 import com.swm.lito.core.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepContribution;

--- a/batch/src/main/java/com/swm/lito/batch/job/RecommendUserJobConfig.java
+++ b/batch/src/main/java/com/swm/lito/batch/job/RecommendUserJobConfig.java
@@ -4,7 +4,7 @@ import com.swm.lito.batch.dto.response.RecommendUserResponse;
 import com.swm.lito.core.common.exception.ApplicationException;
 import com.swm.lito.core.common.exception.batch.BatchErrorCode;
 import com.swm.lito.core.problem.adapter.out.persistence.BatchRepository;
-import com.swm.lito.core.problem.adapter.out.persistence.RecommendUserRepository;
+import com.swm.lito.core.problem.adapter.out.persistence.RecommendUserJdbcRepository;
 import com.swm.lito.core.problem.domain.Batch;
 import com.swm.lito.core.problem.domain.RecommendUser;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ import java.util.List;
 public class RecommendUserJobConfig {
 
     private final BatchRepository batchRepository;
-    private final RecommendUserRepository recommendUserRepository;
+    private final RecommendUserJdbcRepository recommendUserJdbcRepository;
 
     @Value("${ml-server.url}")
     private String ML_SERVER_URL;
@@ -66,7 +66,7 @@ public class RecommendUserJobConfig {
                 List<RecommendUser> recommendUsers = response.getData().stream()
                         .map(r -> RecommendUser.createRecommendUser(r.getUserId(), r.getProblemId()))
                         .toList();
-                recommendUserRepository.saveAll(recommendUsers);
+                recommendUserJdbcRepository.saveRecommendUsers(recommendUsers);
                 return RepeatStatus.FINISHED;
             }
         };

--- a/core/src/main/java/com/swm/lito/core/problem/adapter/out/persistence/RecommendUserJdbcRepository.java
+++ b/core/src/main/java/com/swm/lito/core/problem/adapter/out/persistence/RecommendUserJdbcRepository.java
@@ -1,0 +1,32 @@
+package com.swm.lito.core.problem.adapter.out.persistence;
+
+import com.swm.lito.core.problem.domain.RecommendUser;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@Repository
+public class RecommendUserJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public RecommendUserJdbcRepository(DataSource dataSource){
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public void saveRecommendUsers(List<RecommendUser> recommendUsers){
+        String sql = "INSERT INTO RECOMMEND_USER (user_id, problem_id, status, created_at, updated_at) " +
+                " VALUES (?, ?, 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
+
+        jdbcTemplate.batchUpdate(sql,
+                recommendUsers,
+                recommendUsers.size(),
+                (PreparedStatement ps, RecommendUser recommendUser) ->{
+                    ps.setLong(1, recommendUser.getUserId());
+                    ps.setLong(2, recommendUser.getProblemId());
+                });
+    }
+}


### PR DESCRIPTION
## 작업내용
-  batch 작업에서 recommend user 엔티티 저장시 jpa의 saveAll이 아닌 jdbc의  bulk insert로 변경


## 기대효과
- 10만개 데이터 기준 14분 12초 -> 3.8초로 단축