### PR TITLE
[LITO-212] fix: spring security 유저 검증시 email과 provider를 체크함으로써 email이 같은 oauth 구별

### DIFF
--- a/api/src/main/java/com/lito/api/common/security/CustomUserDetailsService.java
+++ b/api/src/main/java/com/lito/api/common/security/CustomUserDetailsService.java
@@ -1,10 +1,13 @@
 package com.lito.api.common.security;
 
+import com.lito.core.auth.application.port.out.AuthQueryPort;
 import com.lito.core.common.exception.ApplicationException;
 import com.lito.core.common.security.AuthUser;
 import com.lito.core.user.application.port.out.UserQueryPort;
 import com.lito.core.user.domain.User;
+import com.lito.core.user.domain.enums.Provider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
@@ -16,12 +19,17 @@ import static com.lito.core.common.exception.user.UserErrorCode.USER_NOT_FOUND;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserQueryPort userQueryPort;
+    private final AuthQueryPort authQueryPort;
+    private Provider provider;
 
     @Override
     public UserDetails loadUserByUsername(String email) {
-        User user = userQueryPort.findByEmail(email)
+        User user = authQueryPort.findByEmailAndProvider(email, provider)
                 .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
         return AuthUser.of(user);
+    }
+
+    public void setProvider(Provider provider){
+        this.provider = provider;
     }
 }

--- a/api/src/main/java/com/lito/api/common/security/jwt/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/lito/api/common/security/jwt/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import com.lito.core.auth.application.port.out.TokenQueryPort;
 import com.lito.api.common.security.CustomUserDetailsService;
 import com.lito.core.common.exception.ApplicationException;
 import com.lito.core.common.security.jwt.JwtProvider;
+import com.lito.core.user.domain.enums.Provider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,6 +41,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String jwt = resolveToken(request);
             if (isValid(jwt)) {
                 String email = jwtProvider.getUserEmail(jwt);
+                Provider provider = Provider.toEnum(jwtProvider.getUserProvider(jwt));
+                customUserDetailsService.setProvider(provider);
                 UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/api/src/test/java/com/lito/api/common/security/CustomUserDetailsServiceTest.java
+++ b/api/src/test/java/com/lito/api/common/security/CustomUserDetailsServiceTest.java
@@ -1,0 +1,100 @@
+package com.lito.api.common.security;
+
+import com.lito.core.common.exception.ApplicationException;
+import com.lito.core.common.exception.user.UserErrorCode;
+import com.lito.core.user.adapter.out.persistence.UserRepository;
+import com.lito.core.user.domain.User;
+import com.lito.core.user.domain.enums.Provider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@DisplayName("CustomUserDetailsService")
+class CustomUserDetailsServiceTest {
+
+    @Autowired
+    CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    UserRepository userRepository;
+
+
+    String email = "test@test.com";
+
+    @BeforeEach
+    void setUp(){
+        userRepository.save(User.builder()
+                .oauthId("kakaoId")
+                .email(email)
+                .provider(Provider.KAKAO)
+                .build());
+        customUserDetailsService.setProvider(Provider.KAKAO);
+    }
+
+    @Nested
+    @DisplayName("loadUserByUsername 메서드는")
+    class load_user_by_username{
+
+        @Nested
+        @DisplayName("email을 가지고")
+        class with_email{
+
+            @Test
+            @DisplayName("UserDetails를 리턴한다.")
+            void it_returns_user_details() throws Exception{
+
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+                assertThat(userDetails.getUsername()).isEqualTo(email);
+
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 유저라면")
+        class with_user_not_found{
+
+            String notFoundEmail = "email";
+
+            @Test
+            @DisplayName("USER_NOT_FOUND 예외를 발생시킨다.")
+            void it_throws_user_not_found() throws Exception{
+
+                assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(notFoundEmail))
+                        .isExactlyInstanceOf(ApplicationException.class)
+                        .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("setProvider 메서드는")
+    class set_provider{
+
+        @Nested
+        @DisplayName("provider를 가지고")
+        class with_provider{
+
+            @Test
+            @DisplayName("CustomUserDetailsService에 변수로 등록된다.")
+            void it_registers_provider() throws Exception{
+
+                assertThatCode(() -> customUserDetailsService.setProvider(Provider.KAKAO))
+                        .doesNotThrowAnyException();
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/com/lito/core/auth/application/port/out/AuthQueryPort.java
+++ b/core/src/main/java/com/lito/core/auth/application/port/out/AuthQueryPort.java
@@ -9,4 +9,6 @@ public interface AuthQueryPort {
 
     Optional<User> findByOauthIdAndProvider(String oauthId, Provider provider);
 
+    Optional<User> findByEmailAndProvider(String email, Provider provider);
+
 }

--- a/core/src/main/java/com/lito/core/common/security/AuthUser.java
+++ b/core/src/main/java/com/lito/core/common/security/AuthUser.java
@@ -25,8 +25,8 @@ public class AuthUser implements UserDetails {
         return user.getId();
     }
 
-    public Provider getProvider() {
-        return user.getProvider();
+    public String getProvider() {
+        return user.getProvider().getName();
     }
 
     public User getUser() {

--- a/core/src/main/java/com/lito/core/common/security/jwt/JwtProvider.java
+++ b/core/src/main/java/com/lito/core/common/security/jwt/JwtProvider.java
@@ -82,6 +82,11 @@ public class JwtProvider implements InitializingBean {
                 .get(USERNAME, String.class);
     }
 
+    public String getUserProvider(String token){
+        return getClaims(token)
+                .get(USER_PROVIDER, String.class);
+    }
+
     public long getRemainingMilliSecondsFromToken(String token){
         Date expiration = getClaims(token).getExpiration();
         return expiration.getTime() - new Date().getTime();

--- a/core/src/main/java/com/lito/core/user/adapter/out/persistence/UserQueryAdapter.java
+++ b/core/src/main/java/com/lito/core/user/adapter/out/persistence/UserQueryAdapter.java
@@ -34,4 +34,9 @@ public class UserQueryAdapter implements AuthQueryPort, UserQueryPort {
     public Optional<User> findByOauthIdAndProvider(String oauthId, Provider provider) {
         return userRepository.findByOauthIdAndProvider(oauthId, provider);
     }
+
+    @Override
+    public Optional<User> findByEmailAndProvider(String email, Provider provider){
+        return userRepository.findByEmailAndProvider(email, provider);
+    }
 }

--- a/core/src/main/java/com/lito/core/user/adapter/out/persistence/UserRepository.java
+++ b/core/src/main/java/com/lito/core/user/adapter/out/persistence/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
     Optional<User> findByOauthIdAndProvider(String oauthId, Provider provider);
+    Optional<User> findByEmailAndProvider(String email, Provider provider);
 }


### PR DESCRIPTION
## 작업내용
- jwt 토큰을 통해 유저의 provider 추출
- customUserDetailsService의 loadUserByUsername 메서드에서 email과 provider를 검증
- customUserDetailsService 테스트 코드 작성