### PR TITLE
[LITO-239] fix: 문제 목록 조회 버그 수정

### DIFF
--- a/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemCustomRepositoryImpl.java
+++ b/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemCustomRepositoryImpl.java
@@ -72,7 +72,7 @@ public class ProblemCustomRepositoryImpl implements ProblemCustomRepository {
                 .select(problem.count())
                 .from(problem)
                 .innerJoin(problem.subject)
-                .leftJoin(problemUser).on(problem.id.eq(problemUser.problem.id))
+                .leftJoin(problemUser).on(problem.id.eq(problemUser.problem.id), problemUser.user.id.eq(userId))
                 .where(eqSubjectId(subjectId), eqProblemStatus(problemStatus),
                         containQuery(query));
 

--- a/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemCustomRepositoryImpl.java
+++ b/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.lito.core.problem.adapter.out.persistence;
 
+import com.lito.core.common.entity.BaseEntity;
 import com.lito.core.problem.application.port.out.response.ProblemPageQueryDslResponseDto;
 import com.lito.core.problem.application.port.out.response.ProblemPageWithFavoriteQResponseDto;
 import com.lito.core.problem.application.port.out.response.ProblemPageWithProcessQResponseDto;
@@ -169,7 +170,8 @@ public class ProblemCustomRepositoryImpl implements ProblemCustomRepository {
 
     private List<Favorite> getFavorites(Long userId, List<Long> problemIds){
         return queryFactory.selectFrom(favorite)
-                .where(favorite.user.id.eq(userId), favorite.problem.id.in(problemIds))
+                .where(favorite.user.id.eq(userId), favorite.status.eq(BaseEntity.Status.ACTIVE),
+                        favorite.problem.id.in(problemIds))
                 .fetch();
     }
 }


### PR DESCRIPTION
## 작업내용
- favorite 엔티티를 조회할 때 status가 default로 ACTIVE로 조회하는 방식을 이전에 리팩토링했음 그러나 QueryDsl을 통해 조회하는 ProblemCustomRepositoryImpl에서 getFavorites메서드에 해당 부분이 적용이 안되서 Map으로 문제 번호와 좋아요 여부를 매핑할시 "Duplicate key 3 (attempted merging values 282 and 303)"에러가 뜬다. => QueryDsl로직에 favorite status 체크하는 조건 로직 추가
- 문제 목록 조회 count 쿼리시 userId 조건이 없어서 올바르지 않은 문제 개수 반환 => count 쿼리에 userId 조건 추가