### PR TITLE
[LITO-240] refactor: 개발 환경에 맞는 저장소 적용 변경

### DIFF
--- a/core/src/main/java/com/lito/core/config/DataSourceConfig.java
+++ b/core/src/main/java/com/lito/core/config/DataSourceConfig.java
@@ -4,10 +4,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 import javax.sql.DataSource;
@@ -15,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
+@Profile("{dev,prod}")
 public class DataSourceConfig {
 
     public static final String PRIMARY_DATASOURCE = "primaryDataSource";

--- a/core/src/main/java/com/lito/core/config/DataSourceConfig.java
+++ b/core/src/main/java/com/lito/core/config/DataSourceConfig.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
-@Profile("{dev,prod}")
+@Profile({"dev","prod"})
 public class DataSourceConfig {
 
     public static final String PRIMARY_DATASOURCE = "primaryDataSource";

--- a/core/src/main/java/com/lito/core/config/RedisClusterConfig.java
+++ b/core/src/main/java/com/lito/core/config/RedisClusterConfig.java
@@ -1,0 +1,27 @@
+package com.lito.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+import java.util.List;
+
+@Configuration
+@EnableRedisRepositories
+@Profile({"dev","prod"})
+public class RedisClusterConfig {
+
+    @Value("${spring.data.redis.cluster.nodes}")
+    private List<String> clusterNodes;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisClusterConfiguration redisClusterConfiguration = new RedisClusterConfiguration(clusterNodes);
+        return new LettuceConnectionFactory(redisClusterConfiguration);
+    }
+}

--- a/core/src/main/java/com/lito/core/config/RedisConfig.java
+++ b/core/src/main/java/com/lito/core/config/RedisConfig.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 
 @Configuration
 @EnableRedisRepositories
+@Profile({"test","dev"})
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -34,21 +34,10 @@ spring:
       port: 6379
 
   datasource:
-    primary:
-      hikari:
-        type: com.zaxxer.hikari.HikariDataSource
-        driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:~/lito;MODE=MySQL;NON_KEYWORDS=USER
-        username: sa
-        password:
-
-    secondary:
-      hikari:
-        type: com.zaxxer.hikari.HikariDataSource
-        driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:~/lito-replication;MODE=MySQL;NON_KEYWORDS=USER
-        username: sa
-        password:
+    url: jdbc:h2:mem:~/lito;MODE=MySQL;NON_KEYWORDS=USER
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
   jpa:
     open-in-view: false
@@ -109,38 +98,27 @@ spring:
       uri: ${MONGO_DB_URI}
 
   datasource:
-    primary:
-      hikari:
-        type: com.zaxxer.hikari.HikariDataSource
-        driver-class-name: com.mysql.cj.jdbc.Driver
-        jdbc-url: ${DEV_DB_URL}
-        username: ${DEV_DB_USERNAME}
-        password: ${DEV_DB_PASSWORD}
-
-    secondary:
-      hikari:
-        type: com.zaxxer.hikari.HikariDataSource
-        driver-class-name: com.mysql.cj.jdbc.Driver
-        jdbc-url: ${DEV_DB_REPLICATION_URL}
-        username: ${DEV_DB_USERNAME}
-        password: ${DEV_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
   jpa:
     open-in-view: false
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         show_sql: true
         format_sql: true
-#    defer-datasource-initialization: true
+    defer-datasource-initialization: true
 
   sql:
     init:
-      mode: never
+      mode: always
 ---
 spring:
   config:

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -149,8 +149,8 @@ spring:
 
   data:
     redis:
-      host: ${DEV_REDIS_HOST}
-      port: ${DEV_REDIS_PORT}
+      cluster:
+        nodes: ${DEV_REDIS_CLUSTER}
 
     mongodb:
       uri: ${DEV_MONGO_DB_URI}

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -8,21 +8,10 @@ spring:
       port: 6379
 
   datasource:
-    primary:
-      hikari:
-        type: com.zaxxer.hikari.HikariDataSource
-        driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:~/lito;MODE=MySQL;NON_KEYWORDS=USER
-        username: sa
-        password:
-
-    secondary:
-      hikari:
-        type: com.zaxxer.hikari.HikariDataSource
-        driver-class-name: org.h2.Driver
-        jdbc-url: jdbc:h2:mem:~/lito-replication;MODE=MySQL;NON_KEYWORDS=USER
-        username: sa
-        password:
+    url: jdbc:h2:mem:~/lito;MODE=MySQL;NON_KEYWORDS=USER
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
   jpa:
     open-in-view: false


### PR DESCRIPTION
## 작업내용
- dev환경은 redis cluster가 적용되어 있으므로 클러스터 노드에 맞는 RedisClusterConfig 적용
- RDS는 DB Replication이 적용되어 있으므로 DataSoucreConfig에 dev,prod 프로필 명시 적용