### PR TITLE
[LITO-240] fix: redis config profile 오타

### DIFF
--- a/core/src/main/java/com/lito/core/config/RedisConfig.java
+++ b/core/src/main/java/com/lito/core/config/RedisConfig.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 
 @Configuration
 @EnableRedisRepositories
-@Profile({"test","dev"})
+@Profile({"test","local"})
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")


### PR DESCRIPTION
## 작업내용
- RedisConfig 클래스 @Profile에 local 명시가 아닌 dev로 오타