### PR TITLE
[LITO-253] fix: 문제 목록 조회 order by 정렬 대상 변경

### DIFF
--- a/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemCustomRepositoryImpl.java
+++ b/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemCustomRepositoryImpl.java
@@ -49,7 +49,7 @@ public class ProblemCustomRepositoryImpl implements ProblemCustomRepository {
                 .leftJoin(problemUser).on(problem.id.eq(problemUser.problem.id), problemUser.user.id.eq(userId))
                 .where(eqSubjectId(subjectId), eqProblemStatus(problemStatus),
                         containQuery(query))
-                .orderBy(statusOrder.desc(), problemUser.id.desc())
+                .orderBy(statusOrder.desc(), problem.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/core/src/main/resources/data.sql
+++ b/core/src/main/resources/data.sql
@@ -41,6 +41,7 @@ INSERT INTO SUBJECT_CATEGORY(id, subject_category_name, status, created_at, upda
 INSERT INTO SUBJECT_CATEGORY(id, subject_category_name, status, created_at, updated_at) VALUES(41, '해싱','ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO SUBJECT_CATEGORY(id, subject_category_name, status, created_at, updated_at) VALUES(42, '탐색','ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO SUBJECT_CATEGORY(id, subject_category_name, status, created_at, updated_at) VALUES(43, '알고리즘','ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO SUBJECT_CATEGORY(id, subject_category_name, status, created_at, updated_at) VALUES(44, '기타','ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 
 INSERT INTO SUBJECT(id, subject_name, status, created_at, updated_at) VALUES(1, '운영체제','ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);


### PR DESCRIPTION
## 작업내용
- problemUser를 기준으로 생성일 내림차순으로 정렬되었던 문제 목록을 problem을 기준으로 변경