### PR TITLE
[LITO-255] fix: @Around  내부 @args 인자 충돌 해결

### DIFF
--- a/admin/src/main/java/com/lito/admin/problem/adapter/in/request/FaqRequest.java
+++ b/admin/src/main/java/com/lito/admin/problem/adapter/in/request/FaqRequest.java
@@ -1,15 +1,13 @@
 package com.lito.admin.problem.adapter.in.request;
 
 import com.lito.core.admin.application.port.in.request.FaqRequestDto;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class FaqRequest {
 
     private String question;

--- a/admin/src/main/java/com/lito/admin/problem/adapter/in/request/ProblemRequest.java
+++ b/admin/src/main/java/com/lito/admin/problem/adapter/in/request/ProblemRequest.java
@@ -4,10 +4,7 @@ import com.lito.core.admin.application.port.in.request.ProblemRequestDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +14,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class ProblemRequest {
 
     @NotNull(message = "subjectId를 입력해주세요.")

--- a/api/src/main/java/com/lito/api/auth/adapter/in/request/LoginRequest.java
+++ b/api/src/main/java/com/lito/api/auth/adapter/in/request/LoginRequest.java
@@ -3,7 +3,10 @@ package com.lito.api.auth.adapter.in.request;
 import com.lito.core.auth.application.port.in.request.LoginRequestDto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor

--- a/api/src/main/java/com/lito/api/chat/adapter/in/request/ChatGPTCompletionRequest.java
+++ b/api/src/main/java/com/lito/api/chat/adapter/in/request/ChatGPTCompletionRequest.java
@@ -1,15 +1,13 @@
 package com.lito.api.chat.adapter.in.request;
 
 import com.lito.core.chat.application.port.in.request.ChatGPTCompletionRequestDto;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class ChatGPTCompletionRequest {
 
     private String message;

--- a/api/src/main/java/com/lito/api/problem/adapter/in/request/ProblemSubmitRequest.java
+++ b/api/src/main/java/com/lito/api/problem/adapter/in/request/ProblemSubmitRequest.java
@@ -2,15 +2,13 @@ package com.lito.api.problem.adapter.in.request;
 
 import com.lito.core.problem.application.port.in.request.ProblemSubmitRequestDto;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@ToString
 public class ProblemSubmitRequest {
 
     @NotBlank(message = "키워드를 입력해주세요.")

--- a/api/src/main/java/com/lito/api/user/adapter/in/request/ProfileRequest.java
+++ b/api/src/main/java/com/lito/api/user/adapter/in/request/ProfileRequest.java
@@ -2,15 +2,13 @@ package com.lito.api.user.adapter.in.request;
 
 import com.lito.core.user.application.port.in.request.ProfileRequestDto;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class ProfileRequest {
 
     @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 작성해주세요.")

--- a/api/src/main/java/com/lito/api/user/adapter/in/request/UserRequest.java
+++ b/api/src/main/java/com/lito/api/user/adapter/in/request/UserRequest.java
@@ -2,16 +2,14 @@ package com.lito.api.user.adapter.in.request;
 
 import com.lito.core.user.application.port.in.request.UserRequestDto;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class UserRequest {
 
     @NotBlank(message = "닉네임을 입력해주세요.")

--- a/api/src/main/java/com/lito/api/user/adapter/in/request/UserRequest.java
+++ b/api/src/main/java/com/lito/api/user/adapter/in/request/UserRequest.java
@@ -19,7 +19,7 @@ public class UserRequest {
     private String introduce;
 
     @NotBlank(message = "이름을 입력해주세요.")
-    @Length(min = 2, max = 10, message = "이름은 2자 이상 10자 이하로 작성해주세요.")
+    @Length(min = 2, max = 20, message = "이름은 2자 이상 20자 이하로 작성해주세요.")
     private String name;
 
     public UserRequestDto toRequestDto(){

--- a/support/logging/build.gradle
+++ b/support/logging/build.gradle
@@ -2,4 +2,6 @@ dependencies {
 
     //aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }

--- a/support/logging/src/main/java/com/lito/logging/LogAspect.java
+++ b/support/logging/src/main/java/com/lito/logging/LogAspect.java
@@ -1,21 +1,19 @@
 package com.lito.logging;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.multipart.MultipartHttpServletRequest;
-import org.springframework.web.multipart.support.DefaultMultipartHttpServletRequest;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.stream.Collectors;
 
 
 @Component
@@ -23,11 +21,28 @@ import java.util.Map;
 @Slf4j
 public class LogAspect {
 
-    @Around("execution(* com.lito..*Controller.*(..)) && args(.., @RequestBody body) && args(.., @RequestPart file)")
-    public Object logging(ProceedingJoinPoint pjp, Object body, MultipartFile file) throws Throwable{
+    @Around("execution(* com.lito..*Controller.*(..))")
+    public Object logging(ProceedingJoinPoint pjp) throws Throwable{
+        Map<String, Object> data = getRequestMap(pjp);
+        
+        long startAt = System.currentTimeMillis();
+        log.info("----------> Request: {}", data);
+
+        Object result = pjp.proceed(pjp.getArgs());
+
+        long endAt = System.currentTimeMillis();
+
+        log.info("----------> RESPONSE : {}({}) => {} ({}ms)", pjp.getSignature().getDeclaringTypeName(),
+                pjp.getSignature().getName(), result, endAt - startAt);
+
+        return result;
+    }
+
+    private static Map<String, Object> getRequestMap(ProceedingJoinPoint pjp) {
         HttpServletRequest request =
                 ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        ObjectMapper objectMapper = new ObjectMapper();
+
+
         Map<String, Object> data = new HashMap<>();
 
         data.put("host", request.getRemoteHost());
@@ -36,26 +51,16 @@ public class LogAspect {
         data.put("request-query_params", request.getQueryString());
         data.put("request-headers", request.getHeader("Authorization"));
         data.put("method-name", pjp.getSignature().getName());
+        data.put("request-body",  getRequestBody(pjp));
 
-        if (!request.getMethod().equals("GET") && body != null && file == null) {
-            data.put("request-body", objectMapper.writeValueAsString(body));
-        }
+        return data;
+    }
 
-        if(file!=null){
-            data.put("request-part", file.getOriginalFilename());
-        }
-
-        long startAt = System.currentTimeMillis();
-        log.info("----------> Request: {}", data);
-
-        Object result = pjp.proceed();
-
-        long endAt = System.currentTimeMillis();
-
-        log.info("----------> RESPONSE : {}({}) => {} ({}ms)", pjp.getSignature().getDeclaringTypeName(),
-                pjp.getSignature().getName(), result, endAt - startAt);
-
-        return result;
+    private static String getRequestBody(ProceedingJoinPoint pjp){
+        return Arrays.stream(pjp.getArgs())
+                .filter(arg -> !(arg instanceof UserDetails))
+                .map(Object::toString)
+                .collect(Collectors.joining(", "));
     }
 
 }


### PR DESCRIPTION
## 작업내용
- @Around 내부 @args로 RequestBody, RequestPart를 설정할 시 RequestPart에선 정상 작동하지만 RequestBody 로깅이 되지 않는 현상 발생
    - ProceedingJoinPoint의 Args를 받아와 요청값 로깅하는 방식으로 변경
-  이름 길이 제한 10 -> 20자로 변경