### PR TITLE
[LITO-257] refactor: 로깅에서 클라이언트 ip 추출 메서드 추가

### DIFF
--- a/support/logging/src/main/java/com/lito/logging/LogAspect.java
+++ b/support/logging/src/main/java/com/lito/logging/LogAspect.java
@@ -45,7 +45,7 @@ public class LogAspect {
 
         Map<String, Object> data = new HashMap<>();
 
-        data.put("host", request.getRemoteHost());
+        data.put("host", getClientIp(request));
         data.put("request-method", request.getMethod());
         data.put("request-uri", request.getRequestURI());
         data.put("request-query_params", request.getQueryString());
@@ -55,6 +55,13 @@ public class LogAspect {
 
         return data;
     }
+
+    private static String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if(ip==null)    ip = request.getRemoteAddr();
+        return ip;
+    }
+
 
     private static String getRequestBody(ProceedingJoinPoint pjp){
         return Arrays.stream(pjp.getArgs())


### PR DESCRIPTION
## 작업내용
- 로드 밸런서를 통해 WAS에 전달되기 때문에 클라이언트 ip를 추출하기 위해 X-Forwarded-For 헤더 추출