### PR TITLE
[Hotfix] v1.1.1

### DIFF
--- a/admin/src/main/java/com/lito/admin/common/exception/ErrorResponse.java
+++ b/admin/src/main/java/com/lito/admin/common/exception/ErrorResponse.java
@@ -87,17 +87,9 @@ public class ErrorResponse {
         return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage(), ServerErrorCode.SERVER_ERROR);
     }
 
-    public static ErrorResponse fromUnauthorizedAtFilter() {
-        return new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), AuthErrorCode.UNAUTHORIZED);
-    }
-
-    public static ErrorResponse fromForbiddenAtFilter() {
-        return new ErrorResponse(HttpStatus.FORBIDDEN.value(), AuthErrorCode.FORBIDDEN);
-    }
-
-    public static ErrorResponse fromJwtExceptionFilter(ErrorEnumCode errorEnumCode){
-        return new ErrorResponse(HttpStatus.UNAUTHORIZED.value(), errorEnumCode);
-    }
+   public static ErrorResponse fromDataIntegrityException(){
+        return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ClientErrorCode.DATA_INTEGRITY);
+   }
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/admin/src/main/java/com/lito/admin/common/exception/GlobalExceptionHandler.java
+++ b/admin/src/main/java/com/lito/admin/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.lito.admin.common.exception;
 
 import com.lito.core.common.exception.ApplicationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MissingPathVariableException;
@@ -55,5 +56,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> serverException(Exception e) {
         log.error(e.getMessage());
         return ResponseEntity.internalServerError().body(ErrorResponse.fromServerException(e));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> dataIntegrityException(DataIntegrityViolationException e){
+        log.error(e.getMessage());
+        return ResponseEntity.badRequest().body(ErrorResponse.fromDataIntegrityException());
     }
 }

--- a/core/src/main/java/com/lito/core/common/exception/ClientErrorCode.java
+++ b/core/src/main/java/com/lito/core/common/exception/ClientErrorCode.java
@@ -10,8 +10,8 @@ public enum ClientErrorCode implements ErrorEnumCode {
     INVALID_VALUE("V001", "입력 값에 대한 예외입니다."),
     MISMATCH_TYPE("V002", "형변환 중 예외가 발생했습니다. 값을 입력형식에 맞게 입력해주세요."),
     EMPTY_QUERY_STRING("V003","Query String을 입력해주세요."),
-    EMPTY_PATH_VARIABLE("V004","Path Variable을 입력해주세요.")
-
+    EMPTY_PATH_VARIABLE("V004","Path Variable을 입력해주세요."),
+    DATA_INTEGRITY("V005", "동시 요청으로인한 예외입니다."),
     ;
 
     private final String code;

--- a/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemUserRepository.java
+++ b/core/src/main/java/com/lito/core/problem/adapter/out/persistence/ProblemUserRepository.java
@@ -1,12 +1,11 @@
 package com.lito.core.problem.adapter.out.persistence;
 
-import com.lito.core.problem.domain.ProblemUser;
-import com.lito.core.user.domain.User;
 import com.lito.core.problem.domain.Problem;
+import com.lito.core.problem.domain.ProblemUser;
 import com.lito.core.problem.domain.enums.ProblemStatus;
+import com.lito.core.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 

--- a/core/src/main/java/com/lito/core/problem/domain/Favorite.java
+++ b/core/src/main/java/com/lito/core/problem/domain/Favorite.java
@@ -9,7 +9,12 @@ import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Table(name = "FAVORITE")
+@Table(name = "FAVORITE", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "user_problem_unique",
+                columnNames = {"user_id", "problem_id"}
+        )
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @SQLDelete(sql = "UPDATE FAVORITE SET status = INACTIVE WHERE id = ?")

--- a/core/src/main/java/com/lito/core/problem/domain/ProblemUser.java
+++ b/core/src/main/java/com/lito/core/problem/domain/ProblemUser.java
@@ -10,7 +10,12 @@ import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
-@Table(name = "PROBLEM_USER")
+@Table(name = "PROBLEM_USER", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "problem_user_unique",
+                columnNames = {"problem_id","user_id"}
+        )
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Where(clause = "status='ACTIVE'")


### PR DESCRIPTION
## 상황
- problem_user 테이블 데이터가 API 동시 요청으로 problem_id와 user_id 가 중복으로 생성되는 버그 발생

## 작업내용
- problem_user테이블 unique 제약 조건으로 인한 데이터 무결성 문제 해결
- favorite 테이블 또한 같은 문제 발생 소지가 있기 때문에 unique 제약 조건 생성