### PR TITLE
[LITO-273] refactor: 도메인 테스트에 있던 불필요한 통합테스트 제거

### DIFF
--- a/core/src/test/java/com/lito/core/auth/domain/LogoutAccessTokenTest.java
+++ b/core/src/test/java/com/lito/core/auth/domain/LogoutAccessTokenTest.java
@@ -1,6 +1,5 @@
 package com.lito.core.auth.domain;
 
-import com.lito.core.auth.domain.LogoutAccessToken;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/com/lito/core/auth/domain/RefreshTokenTest.java
+++ b/core/src/test/java/com/lito/core/auth/domain/RefreshTokenTest.java
@@ -1,6 +1,5 @@
 package com.lito.core.auth.domain;
 
-import com.lito.core.auth.domain.RefreshToken;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/com/lito/core/chat/domain/ChatTest.java
+++ b/core/src/test/java/com/lito/core/chat/domain/ChatTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
-@SpringBootTest
 @DisplayName("Chat")
 class ChatTest {
 

--- a/core/src/test/java/com/lito/core/problem/domain/BatchTest.java
+++ b/core/src/test/java/com/lito/core/problem/domain/BatchTest.java
@@ -1,6 +1,5 @@
 package com.lito.core.problem.domain;
 
-import com.lito.core.problem.domain.Batch;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,6 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
-@SpringBootTest
-@Transactional
 @DisplayName("Batch")
 class BatchTest {
 

--- a/core/src/test/java/com/lito/core/problem/domain/FaqTest.java
+++ b/core/src/test/java/com/lito/core/problem/domain/FaqTest.java
@@ -1,18 +1,13 @@
 package com.lito.core.problem.domain;
 
-import com.lito.core.problem.domain.Faq;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
-@SpringBootTest
-@Transactional
 @DisplayName("FAQ")
 class FaqTest {
 

--- a/core/src/test/java/com/lito/core/problem/domain/FavoriteTest.java
+++ b/core/src/test/java/com/lito/core/problem/domain/FavoriteTest.java
@@ -1,67 +1,42 @@
 package com.lito.core.problem.domain;
 
-import com.lito.core.problem.adapter.out.persistence.ProblemRepository;
-import com.lito.core.problem.domain.*;
-import com.lito.core.user.adapter.out.persistence.UserRepository;
 import com.lito.core.user.domain.User;
 import com.lito.core.user.domain.enums.Provider;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
-@SpringBootTest
-@Transactional
 @DisplayName("Favorite")
 class FavoriteTest {
-
-    @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    ProblemRepository problemRepository;
-
-
-    User user = User.builder()
-            .oauthId("kakaoId")
-            .email("test@test.com")
-            .provider(Provider.KAKAO)
-            .build();
-
-    Problem problem = Problem.builder()
-            .subject(Subject.builder()
-                    .subjectName("운영체제")
-                    .build())
-            .subjectCategory(SubjectCategory.builder()
-                    .subjectCategoryName("프로세스관리")
-                    .build())
-            .question("문맥 전환이 무엇인가?")
-            .answer("CPU가 이전 상태의 프로세스를 PCB에 보관하고, 또 다른 프로세스를 PCB에서 읽어 레지스터에 적재하는 과정")
-            .keyword("PCB")
-            .faqs(List.of(Faq.createFaq("PCB란?", "PCB 는 특정프로세스에 대한 중요한 정보를 저장하고 있는 운영체제의 자료구조이다")))
-            .build();
-
-    Long problemId;
-    Long userId;
-
-    @BeforeEach
-    void setUp(){
-        problemId = problemRepository.save(problem).getId();
-        userId = userRepository.save(user).getId();
-    }
 
     @Nested
     @DisplayName("createFavorite")
     class create_favorite{
+
+        User user = User.builder()
+                .oauthId("kakaoId")
+                .email("test@test.com")
+                .provider(Provider.KAKAO)
+                .build();
+
+        Problem problem = Problem.builder()
+                .subject(Subject.builder()
+                        .subjectName("운영체제")
+                        .build())
+                .subjectCategory(SubjectCategory.builder()
+                        .subjectCategoryName("프로세스관리")
+                        .build())
+                .question("문맥 전환이 무엇인가?")
+                .answer("CPU가 이전 상태의 프로세스를 PCB에 보관하고, 또 다른 프로세스를 PCB에서 읽어 레지스터에 적재하는 과정")
+                .keyword("PCB")
+                .faqs(List.of(Faq.createFaq("PCB란?", "PCB 는 특정프로세스에 대한 중요한 정보를 저장하고 있는 운영체제의 자료구조이다")))
+                .build();
 
         @Nested
         @DisplayName("user, problem을 가지고")
@@ -73,8 +48,13 @@ class FavoriteTest {
 
                 Favorite favorite = Favorite.createFavorite(user, problem);
 
-                assertThat(favorite.getUser().getId()).isEqualTo(userId);
-                assertThat(favorite.getProblem().getId()).isEqualTo(problemId);
+                assertThat(favorite.getUser())
+                        .extracting("oauthId","email","provider")
+                        .contains(user.getOauthId(),user.getEmail(),user.getProvider());
+
+                assertThat(favorite.getProblem())
+                        .extracting("question","answer","keyword")
+                        .contains(problem.getQuestion(),problem.getAnswer(),problem.getKeyword());
             }
         }
     }

--- a/core/src/test/java/com/lito/core/problem/domain/ProblemTest.java
+++ b/core/src/test/java/com/lito/core/problem/domain/ProblemTest.java
@@ -1,23 +1,16 @@
 package com.lito.core.problem.domain;
 
-import com.lito.core.problem.domain.Faq;
-import com.lito.core.problem.domain.Problem;
-import com.lito.core.problem.domain.Subject;
-import com.lito.core.problem.domain.SubjectCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Problem")
 @ActiveProfiles("test")
-@SpringBootTest
 class ProblemTest {
 
     @Nested

--- a/core/src/test/java/com/lito/core/problem/domain/ProblemUserTest.java
+++ b/core/src/test/java/com/lito/core/problem/domain/ProblemUserTest.java
@@ -1,16 +1,11 @@
 package com.lito.core.problem.domain;
 
-import com.lito.core.problem.adapter.out.persistence.ProblemRepository;
-import com.lito.core.problem.domain.*;
 import com.lito.core.problem.domain.enums.ProblemStatus;
-import com.lito.core.user.adapter.out.persistence.UserRepository;
 import com.lito.core.user.domain.User;
 import com.lito.core.user.domain.enums.Provider;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +15,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
-@SpringBootTest
-@Transactional
 @DisplayName("ProblemUser")
 class ProblemUserTest {
-
-    @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    ProblemRepository problemRepository;
 
 
     User user = User.builder()

--- a/core/src/test/java/com/lito/core/problem/domain/RecommendUserTest.java
+++ b/core/src/test/java/com/lito/core/problem/domain/RecommendUserTest.java
@@ -1,18 +1,13 @@
 package com.lito.core.problem.domain;
 
-import com.lito.core.problem.domain.RecommendUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
-@SpringBootTest
-@Transactional
 @DisplayName("RecommendUser")
 class RecommendUserTest {
 

--- a/core/src/test/java/com/lito/core/user/domain/UserTest.java
+++ b/core/src/test/java/com/lito/core/user/domain/UserTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("User")
 @ActiveProfiles("test")
-@SpringBootTest
 class UserTest {
 
     User user = User.builder()

--- a/core/src/test/java/com/lito/core/user/domain/enums/ProviderTest.java
+++ b/core/src/test/java/com/lito/core/user/domain/enums/ProviderTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
-@SpringBootTest
 @DisplayName("Provider")
 class ProviderTest {
 


### PR DESCRIPTION
## 작업내용
- chat, batch,faq, favorite, problem, problemUser, RecommendUser, User, Provider 도메인에 존재하던 @SpringBootTest와 @Transactional 어노테이션 제거
- 단위 테스트로 가능한 부분이 불필요하게 통합 테스트로 실행되고 있었음